### PR TITLE
lib: make `Server.stop` fail nicely

### DIFF
--- a/src/lib/ketrew_error.ml
+++ b/src/lib/ketrew_error.ml
@@ -45,7 +45,7 @@ let to_string = function
 | `Volume (`No_size l) ->
   fmt "Did not get the size of the volume: %s" (Log.to_long_string l)
 | `Start_server_error e -> fmt "Error starting the server: %s" e
-| `Stop_server_error e -> fmt "Error starting the server: %s" e
+| `Stop_server_error e -> fmt "Error stopping the server: %s" e
 | `Wrong_http_request (short, long) ->
   fmt "Wrong HTTP Request: %s → %s" short long
 | `Client (`Get_exn e) ->


### PR DESCRIPTION
Now we fail when the commad pipe is not a FIFO or does not exist.
