### PR TITLE
lib: make the engine less concurrent

### DIFF
--- a/src/lib/ketrew_engine.ml
+++ b/src/lib/ketrew_engine.ml
@@ -774,7 +774,7 @@ let step t: (happening list, _) Deferred_result.t =
   begin
     current_targets t >>= fun targets ->
     database t >>= fun db ->
-    Deferred_list.for_concurrent targets ~f:(fun target ->
+    Deferred_list.for_sequential targets ~f:(fun target ->
         (* Log.(s "Engine.step dealing with " % Target.log target @ verbose); *)
         match target.Target.history with
         | `Created _ -> (* nothing to do *) return []


### PR DESCRIPTION
This is a “temporary” fix for the issue #89. It makes Ketrew significantly
slower but at least it does not overflow picky SSH servers with many
connections.

The long-term solution should come from #73 and #69.
