### PR TITLE
Unrestify the HTTP API

### DIFF
--- a/src/atd/protocol_v0.atd
+++ b/src/atd/protocol_v0.atd
@@ -27,7 +27,15 @@ type down_message = [
   | Ok
 ]
 
+type up_message = [
+  | Get_targets of string list (* List of Ids, empty means “all” *)
+]
+
+(* Temporary backwards compatible message, that will be all in `up_message`
+   at some point *)
 type post_message = [
   | List_of_targets of target_v0 list
   | List_of_target_ids of string list
+  | inherit up_message
 ]
+

--- a/src/atd/protocol_v0.atd
+++ b/src/atd/protocol_v0.atd
@@ -30,6 +30,7 @@ type down_message = [
 type up_message = [
   | Get_targets of string list (* List of Ids, empty means “all” *)
   | Get_available_queries of string (* Id of the target *)
+  | Call_query of (string * string) (* target-id × query-name *)
 ]
 
 (* Temporary backwards compatible message, that will be all in `up_message`

--- a/src/atd/protocol_v0.atd
+++ b/src/atd/protocol_v0.atd
@@ -32,6 +32,8 @@ type up_message = [
   | Get_available_queries of string (* Id of the target *)
   | Call_query of (string * string) (* target-id × query-name *)
   | Submit_targets of target_v0 list
+  | Kill_targets of string list (* List of Ids *)
+  | Restart_targets of string list (* List of Ids *)
 ]
 
 (* Temporary backwards compatible message, that will be all in `up_message`

--- a/src/atd/protocol_v0.atd
+++ b/src/atd/protocol_v0.atd
@@ -36,11 +36,4 @@ type up_message = [
   | Restart_targets of string list (* List of Ids *)
 ]
 
-(* Temporary backwards compatible message, that will be all in `up_message`
-   at some point *)
-type post_message = [
-  | List_of_targets of target_v0 list
-  | List_of_target_ids of string list
-  | inherit up_message
-]
 

--- a/src/atd/protocol_v0.atd
+++ b/src/atd/protocol_v0.atd
@@ -29,6 +29,7 @@ type down_message = [
 
 type up_message = [
   | Get_targets of string list (* List of Ids, empty means “all” *)
+  | Get_available_queries of string (* Id of the target *)
 ]
 
 (* Temporary backwards compatible message, that will be all in `up_message`

--- a/src/atd/protocol_v0.atd
+++ b/src/atd/protocol_v0.atd
@@ -31,6 +31,7 @@ type up_message = [
   | Get_targets of string list (* List of Ids, empty means “all” *)
   | Get_available_queries of string (* Id of the target *)
   | Call_query of (string * string) (* target-id × query-name *)
+  | Submit_targets of target_v0 list
 ]
 
 (* Temporary backwards compatible message, that will be all in `up_message`

--- a/src/atd/versioned.atd
+++ b/src/atd/versioned.atd
@@ -50,6 +50,6 @@ type down_message_v0
      <ocaml from="Ketrew_gen_protocol_v0.Down_message" > = abstract
 type down_message = [ V0 of down_message_v0 ]
 
-type post_message_v0 
-     <ocaml from="Ketrew_gen_protocol_v0.Post_message" > = abstract
-type post_message = [ V0 of post_message_v0 ]
+type up_message_v0 
+     <ocaml from="Ketrew_gen_protocol_v0.Up_message" > = abstract
+type up_message = [ V0 of up_message_v0 ]

--- a/src/doc/The_HTTP_API.md
+++ b/src/doc/The_HTTP_API.md
@@ -1,6 +1,8 @@
 When Ketrew Replies on HTTP
 ===========================
 
+<span style="color: red">Warning: </span>
+This is outdated while we work on the next version.
 
 Examples
 --------

--- a/src/doc/The_HTTP_API.md
+++ b/src/doc/The_HTTP_API.md
@@ -1,9 +1,6 @@
 When Ketrew Replies on HTTP
 ===========================
 
-<span style="color: red">Warning: </span>
-This is outdated while we work on the next version.
-
 Examples
 --------
 
@@ -22,155 +19,49 @@ You should be able to stop it with
 
 Let's add some targets to the database (c.f. `src/test/Workflow_Examples.ml`):
 
-    kdtest website master
+    kdtest two-py /tmp "du -sh $HOME" "du -sh $PWD"
 
 You can always browse with the client working like in standalone mode:
 
     kdclient interact
 
-Let's see the API itself, we use `curl`, here on the `/targets` service:
+Let's see the API itself, we use `curl`, and we `POST` messages to the `/api`
+service:
 
-    curl -k "$ktest_url/targets"
-
-The option `return-error-messages` is set to true, so the server is nice and
-says what went wrong:
-
-```badresult
-Error: Wrong HTTP Request: Authentication → Insufficient credentials
-```
-
-In `_obuild/test-authorized-tokens` there is an “easy token” `"nekot"`:
-
-    curl -k "$ktest_url/targets?token=nekot"
-
-```badresult
-Error: Wrong HTTP Request: format-mandatory-parameter → Missing mandatory parameter: "format"
-```
-
-Let's try again:
-
-    curl -k "$ktest_url/targets?token=nekot&format=json" | less
-
-Yay we get some Json \o/ i.e. a list of target JSON representations:
+    json='["V0", [ "Get_targets", [] ] ]'
+    curl -d "$json" -k "$ktest_url/api?token=nekot"
 
 ```goodresult
-[[
-  "V0",
-  {
-    "history": [
-      "Successful",
-      [
-        1410886910.433017,
-        [
-          "Running",
-          [
-            {
-              "run_history": [
-  ...
-]
-```
-
-We can use `id` parameters to limit the request to one or more
-targets:
-
-    one_of_them="ketrew_2014-11-21-19h44m24s850ms-UTC_994326685"
-    curl -k "$ktest_url/targets?token=nekot&format=json&id=$one_of_them"
-
-```goodresult
-[
-   [
-      "V0",
-      {
-         "history" : [
-            "Created",
-            1408654128.82403
-         ],
-         "make" : [
-            "Direct_command",
-            {
-               "action" : [
-                  "Shell_command",
-                  "git add api && git ci -a -m 'update website' "
-               ],
-               "host" : {
-                  "playground" : [
-                     "Some",
-                     {
-                        "kind" : "Directory",
-                        "path" : "/tmp"
-                     }
-                  ],
-                  "connection" : "Localhost",
-                  "execution_timeout" : "None",
-                  "default_shell" : {
-                     "command_option" : "-c",
-                     "options" : [],
-                     "binary" : "None",
-                     "command_name" : "sh"
-                  },
-                  "name" : "file://tmp"
-               }
-            }
-         ],
-         "dependencies" : [
-            "ketrew_2014-08-21-21h49m48s823ms-UTC_332180439"
-         ],
-         "persistence" : "Input_data",
-         "name" : "Commit",
-         "if_fails_activate" : [
-            "ketrew_2014-08-21-21h49m48s823ms-UTC_641907500"
-         ],
-         "id" : "ketrew_2014-08-21-21h49m48s823ms-UTC_781944104",
-         "metadata" : "Unit",
-         "equivalence" : "Same_active_condition",
-         "condition" : "None"
-      }
-   ]
-]
-```
-
-By the way, the `/targets` service is
-[nullipotent](http://en.wiktionary.org/wiki/nullipotent), and `GET`-only:
-
-    curl -k --data "something to post" "$ktest_url/targets?token=nekot&format=json"
-
-```badresult
-Error: Wrong HTTP Request: wrong method → POST
-```
-
-What additional queries can we get on the targets?
-
-    curl -k "$ktest_url/target-available-queries?token=nekot&format=json&id=$one_of_them"
-
-
-we get a list of `("name", "description")` pairs; the queries that are
-available for this particular target:
-
-```goodresult
-[
-  "V0",
+[ "V0",
   [
-    "List_of_query_descriptions",
+    "List_of_targets",
     [
-      [ "stdout", "Stardard output" ],
-      [ "stderr", "Stardard error" ],
-      [ "log", "Monitored-script `log` file" ],
-      [ "script", "Monitored-script used" ],
-      [ "check-process", "Check the process-group with `ps`" ]
-    ]
-  ]
-]
+      {
+        "tags": [ "website", "end-of-workflow" ],
+        "log": [],
+        "history": [
+          "Finished",
+...
 ```
 
-    curl -k "$ktest_url/target-call-query?token=nekot&format=json&id=$one_of_them&query=log"
+where:
 
-```goodresult
-[
-   "V0",
-   [
-      "Query_result",
-      "start\t2014-11-21 18:44:27\t\nbefore-cmd\t2014-11-21 18:44:27\tCMD0000\tmkdir -p /tmp/deploy_website_ketrew_2014-11-21-19h44m24s848ms-UTC_089809344\nafter-cmd\t2014-11-21 18:44:27\tCMD0000\treturned 0\nbefore-cmd\t2014-11-21 18:44:27\tCMD0001\tcd /tmp/deploy_website_ketrew_2014-11-21-19h44m24s848ms-UTC_089809344\nafter-cmd\t2014-11-21 18:44:27\tCMD0001\treturned 0\nbefore-cmd\t2014-11-21 18:44:27\tCMD0002\tgit clone /Volumes/Encrypted_zzz/dev/ketrew\nafter-cmd\t2014-11-21 18:44:28\tCMD0002\treturned 0\nsuccess\t2014-11-21 18:44:28\t\n"
-   ]
-]
+- The variable `$ktest_url` is provided in `_test_env/env.env`.
+- The parameter `token` is an authentication token (the server reads the file
+  `_test_env/test-authorized-tokens`, where there is an “easy token” `"nekot"`).
+- The `POST` data (`-d $json`) is the serialized up-message.  The available
+  messages are defined in `src/atd/protocol_v0.atd` and tagged with a version.
+
+To find out how to give the right JSON to to the API, you may just check from
+the top-level:
+
+```ocaml
+utop[0]> #require "ketrew";;
+utop[1]> module K = Ketrew_protocol.Up_message;;
+module K = Ketrew_protocol.Up_message
+utop[2]> K.serialize;;
+- : K.t -> bytes = <fun>
+utop[3]> K.serialize (`Get_targets []);;
+- : bytes = "[ \"V0\", [ \"Get_targets\", [] ] ]"
 ```
 

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -113,8 +113,8 @@ module Http_client = struct
 
   let add_targets t ~targets =
     let msg =
-      `List_of_targets (List.map targets ~f:Ketrew_target.to_serializable) in
-    call_json t ~path:"/add-targets" ~meta_meth:(`Post_message msg) 
+      `Submit_targets (List.map targets ~f:Ketrew_target.to_serializable) in
+    call_json t ~path:"/api" ~meta_meth:(`Post_message msg) 
     >>= fun (_: Json.t) ->
     return ()
 

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -138,11 +138,8 @@ module Http_client = struct
 
   let call_query t ~target query =
     let id = Ketrew_target.id target in
-    let args = [
-      "id", id;
-      "query", query;
-    ] in
-    call_json t ~path:"/target-call-query" ~meta_meth:`Get ~args
+    let message = `Call_query (id, query) in
+    call_json t ~path:"/api" ~meta_meth:(`Post_message message)
     >>= fun json ->
     filter_down_message json ~loc:(`Target_query (id, query))
       ~f:(function `Query_result s -> Some s | _ -> None)

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -61,7 +61,7 @@ module Http_client = struct
       match meta_meth with
       | `Get -> `GET, `Empty
       | `Post_message m ->
-        `POST, `String (Ketrew_protocol.Post_message.serialize m)
+        `POST, `String (Ketrew_protocol.Up_message.serialize m)
     in
     let where = `Call (meth, uri) in
     wrap_deferred

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -120,20 +120,12 @@ module Http_client = struct
 
 
   let kill_or_archive t what =
-    let ids, error_loc, path =
-      match what with
-      | `Kill_targets i as e -> i, e, "/kill-targets" 
-      | `Archive_targets i as e -> i, e, "/archive-targets"
-      | `Restart_targets i as e -> i, e, "/restart-targets"
-    in
-    let msg = (`List_of_target_ids ids) in
-    call_json t ~path ~meta_meth:(`Post_message msg)
-    >>= filter_down_message
-      ~loc:error_loc
-      ~f:(function `Ok -> Some () | _ -> None)
+    call_json t ~path:"/api" ~meta_meth:(`Post_message what)
+    >>= fun (_: Json.t) ->
+    return ()
 
   let kill t id_list = kill_or_archive t (`Kill_targets id_list)
-  let archive t id_list = kill_or_archive t (`Archive_targets id_list)
+  let archive t id_list = assert false
   let restart t id_list = kill_or_archive t (`Restart_targets id_list)
 
   let call_query t ~target query =

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -119,14 +119,13 @@ module Http_client = struct
     return ()
 
 
-  let kill_or_archive t what =
+  let kill_or_restart t what =
     call_json t ~path:"/api" ~meta_meth:(`Post_message what)
     >>= fun (_: Json.t) ->
     return ()
 
-  let kill t id_list = kill_or_archive t (`Kill_targets id_list)
-  let archive t id_list = assert false
-  let restart t id_list = kill_or_archive t (`Restart_targets id_list)
+  let kill t id_list = kill_or_restart t (`Kill_targets id_list)
+  let restart t id_list = kill_or_restart t (`Restart_targets id_list)
 
   let call_query t ~target query =
     let id = Ketrew_target.id target in

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -136,16 +136,6 @@ module Http_client = struct
     filter_down_message json ~loc:(`Target_query (id, query))
       ~f:(function `Query_result s -> Some s | _ -> None)
 
-  let call_cleanable_targets ~how_much t =
-    let args = [
-      "howmuch", (match how_much with `Soft -> "soft" | `Hard -> "hard");
-    ] in
-    let loc = (`Cleanable_targets how_much) in
-    call_json t ~path:"/cleanable-targets" ~meta_meth:`Get ~args
-    >>= fun json ->
-    filter_down_message json ~loc
-      ~f:(function `List_of_target_ids s -> Some s | _ -> None)
-
 end
 
 type t = [
@@ -224,18 +214,6 @@ let get_target t ~id =
   | `Http_client c ->
     Http_client.get_target c ~id
 
-
-let targets_to_clean_up t ~how_much =
-  match t with
-  | `Standalone s ->
-    let open Standalone in
-    Ketrew_engine.Target_graph.(
-      get_current s.engine
-      >>= fun graph ->
-      return (targets_to_clean_up graph how_much)
-    )
-  | `Http_client c ->
-    Http_client.call_cleanable_targets ~how_much c
 
 let call_query t ~target query =
   match t with

--- a/src/lib/ketrew_server.ml
+++ b/src/lib/ketrew_server.ml
@@ -306,6 +306,15 @@ let list_cleanable_targets ~server_state ~body req =
     return (`Message (`Json, `List_of_target_ids to_kill))
   )
 
+let api_service ~server_state ~body req =
+  get_post_body req ~body
+  >>= fun body ->
+  message_of_body ~body ~select:(function
+    | `List_of_target_ids t -> Some t
+    | _ -> None)
+  >>= fun target_ids ->
+  wrong_request "Not implemented" "New API"
+
 (** {2 Dispatcher} *)
 
 let handle_request ~server_state ~body req : (answer, _) Deferred_result.t =
@@ -313,6 +322,7 @@ let handle_request ~server_state ~body req : (answer, _) Deferred_result.t =
        @ verbose);
   match Uri.path (Cohttp_lwt_unix.Server.Request.uri req) with
   | "/hello" -> return `Unit
+  | "/api" -> api_service ~server_state ~body req
   | "/targets" -> targets_service ~server_state ~body req
   | "/target-available-queries" ->
     target_available_queries_service ~server_state ~body req

--- a/src/lib/pure/ketrew_protocol.ml
+++ b/src/lib/pure/ketrew_protocol.ml
@@ -56,11 +56,11 @@ module Down_message = struct
   *)
 end
 
-module Post_message = struct
-  type t = Ketrew_gen_protocol_v0.Post_message.t
+module Up_message = struct
+  type t = Ketrew_gen_protocol_v0.Up_message.t
   include Json.Make_versioned_serialization
-      (Ketrew_gen_protocol_v0.Post_message)
-      (Ketrew_gen_versioned.Post_message)
+      (Ketrew_gen_protocol_v0.Up_message)
+      (Ketrew_gen_versioned.Up_message)
 
   let log : t -> Log.t =
     fun _ ->

--- a/src/lib/pure/ketrew_protocol.mli
+++ b/src/lib/pure/ketrew_protocol.mli
@@ -29,15 +29,15 @@ module Down_message : sig
   val log : t -> Ketrew_pervasives.Log.t
 end
 
-module Post_message : sig
-  type t = Ketrew_gen_protocol_v0.Post_message.t
+module Up_message : sig
+  type t = Ketrew_gen_protocol_v0.Up_message.t
 
-  val to_json : Ketrew_gen_protocol_v0.Post_message.t -> CConvYojson.t
+  val to_json : Ketrew_gen_protocol_v0.Up_message.t -> CConvYojson.t
   val of_json_exn :
-    Ketrew_pervasives.Json.t -> Ketrew_gen_protocol_v0.Post_message.t
+    Ketrew_pervasives.Json.t -> Ketrew_gen_protocol_v0.Up_message.t
 
-  val serialize : Ketrew_gen_protocol_v0.Post_message.t -> string
-  val deserialize_exn : string -> Ketrew_gen_protocol_v0.Post_message.t
+  val serialize : Ketrew_gen_protocol_v0.Up_message.t -> string
+  val deserialize_exn : string -> Ketrew_gen_protocol_v0.Up_message.t
 
   val log : t -> Ketrew_pervasives.Log.t
   val to_string_hum : t -> string


### PR DESCRIPTION
Now every up-message is a `POST` to the `/api` service. This makes it much more readable (everything is in `protocol_v0.atd`) and portable (could easily make it work with another transport layer, like SSH or plain TCP).



<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/122)
<!-- Reviewable:end -->
