### PR TITLE
Make Explorer way lazier

### DIFF
--- a/src/atd/protocol_v0.atd
+++ b/src/atd/protocol_v0.atd
@@ -34,6 +34,7 @@ type up_message = [
   | Submit_targets of target_v0 list
   | Kill_targets of string list (* List of Ids *)
   | Restart_targets of string list (* List of Ids *)
+  | Get_target_ids of [ All | Not_finished_before of float ]
 ]
 
 

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -135,6 +135,13 @@ module Http_client = struct
     filter_down_message json ~loc:(`Target_query (id, query))
       ~f:(function `Query_result s -> Some s | _ -> None)
 
+  let get_list_of_target_ids t query =
+    call_json t ~path:"/api" ~meta_meth:(`Post_message (`Get_target_ids query))
+    >>= filter_down_message ~loc:`Targets ~f:(function
+      | `List_of_target_ids l -> Some l
+      | _ -> None)
+
+
 end
 
 type t = [
@@ -213,6 +220,12 @@ let get_target t ~id =
   | `Http_client c ->
     Http_client.get_target c ~id
 
+let get_list_of_target_ids t ~query =
+  match t with
+  | `Standalone s ->
+    Ketrew_engine.get_list_of_ids s.Standalone.engine query
+  | `Http_client c ->
+    Http_client.get_list_of_target_ids c query
 
 let call_query t ~target query =
   match t with

--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -223,7 +223,7 @@ let get_target t ~id =
 let get_list_of_target_ids t ~query =
   match t with
   | `Standalone s ->
-    Ketrew_engine.get_list_of_ids s.Standalone.engine query
+    Ketrew_engine.get_list_of_target_ids s.Standalone.engine query
   | `Http_client c ->
     Http_client.get_list_of_target_ids c query
 

--- a/src/lib/ketrew_command_line.ml
+++ b/src/lib/ketrew_command_line.ml
@@ -450,30 +450,30 @@ let cmdliner_main ?override_configuration ?argv ?(additional_commands=[]) () =
   let inspect_cmd =
     sub_command
       ~term:Term.(
-        pure (fun config_path in_dollar_editor csv since how ->
-            Configuration.get_configuration ?override_configuration config_path
-            >>= fun configuration ->
-            let in_dollar_editor = in_dollar_editor || csv in
-            let format = if csv then `Csv else `Tsv in
-            Ketrew_client.as_client ~configuration
-              ~f:(inspect ~in_dollar_editor ~format ?since how))
-        $ config_file_argument
-        $ Arg.(value @@ flag
-               @@ info ["e"; "view-in-editor"]
-                 ~doc:"Open stuff in $EDITOR (by default in TSV).")
-        $ Arg.(value @@ flag
-               @@ info ["csv"]
-                 ~doc:"Output CSV instead of TSV (implies `--view-in-editor`).")
-        $ Arg.(value & opt (some string) None
-               & info ["S"; "since"] ~docv:"TIME-STRING"
-                 ~doc:(fmt
-                         "Get measurements that are younger than $(docv); \
-                          the date-format is (any prefix of) `%s`"
-                         Time.(now () |> to_filename)))
-        $ Arg.(non_empty @@ pos_all string [] @@
-               info [] ~docv:"HOW"
-                 ~doc:"How to do the inspection")
-      )
+          pure (fun config_path in_dollar_editor csv since how ->
+              Configuration.get_configuration ?override_configuration config_path
+              >>= fun configuration ->
+              let in_dollar_editor = in_dollar_editor || csv in
+              let format = if csv then `Csv else `Tsv in
+              Ketrew_client.as_client ~configuration
+                ~f:(inspect ~in_dollar_editor ~format ?since how))
+          $ config_file_argument
+          $ Arg.(value @@ flag
+                 @@ info ["e"; "view-in-editor"]
+                   ~doc:"Open stuff in $EDITOR (by default in TSV).")
+          $ Arg.(value @@ flag
+                 @@ info ["csv"]
+                   ~doc:"Output CSV instead of TSV (implies `--view-in-editor`).")
+          $ Arg.(value & opt (some string) None
+                 & info ["S"; "since"] ~docv:"TIME-STRING"
+                   ~doc:(fmt
+                           "Get measurements that are younger than $(docv); \
+                            the date-format is (any prefix of) `%s`"
+                           Time.(now () |> to_filename)))
+          $ Arg.(non_empty @@ pos_all string [] @@
+                 info [] ~docv:"HOW"
+                   ~doc:"How to do the inspection")
+        )
       ~info:(
         let man = [
           `S "THE HOW ARGUMENT";
@@ -513,7 +513,7 @@ let cmdliner_main ?override_configuration ?argv ?(additional_commands=[]) () =
           `I ("`step`", "run one single step"); `Noblank;
           `I ("`fix`", "run  steps until nothing new happens"); `Noblank;
           `I ("`loop`", "loop `fix` until pressing 'q' (there is a \
-                        timed-wait starting at 2 seconds until `--max-sleep`)")
+                         timed-wait starting at 2 seconds until `--max-sleep`)")
         ] in
         info "run-engine" ~version ~sdocs:"COMMON OPTIONS"
           ~doc:"Run steps of the engine."  ~man)
@@ -548,8 +548,8 @@ let cmdliner_main ?override_configuration ?argv ?(additional_commands=[]) () =
             >>= fun configuration ->
             Log.(s "From " %
                  (match override_configuration with
-                  | None -> sf "%S" config_path
-                  | Some _ -> s "user-overriden")
+                 | None -> sf "%S" config_path
+                 | Some _ -> s "user-overriden")
                  % s ":" % n
                  % Configuration.log configuration
                  @ normal); return ())

--- a/src/lib/ketrew_command_line.ml
+++ b/src/lib/ketrew_command_line.ml
@@ -328,7 +328,7 @@ let interact ~client =
       >>= fun () ->
       main_loop ()
     | `Explore ->
-      Explorer.explore ~client []
+      Explorer.(create ~client () |> explore)
       >>= fun () ->
       main_loop ()
   in
@@ -578,7 +578,8 @@ let cmdliner_main ?override_configuration ?argv ?(additional_commands=[]) () =
             Configuration.get_configuration ?override_configuration config_path
             >>= fun configuration ->
             Ketrew_client.as_client ~configuration
-              ~f:(Explorer.explore []))
+              ~f:Explorer.(fun ~client -> create ~client () |> explore)
+          )
         $ config_file_argument)
       ~info:(
         info "explore" ~version ~sdocs:"COMMON OPTIONS"

--- a/src/lib/ketrew_engine.ml
+++ b/src/lib/ketrew_engine.ml
@@ -803,6 +803,22 @@ let get_status t id =
   get_target t id >>= fun target ->
   return (Target.state target) 
 
+let get_list_of_ids t query =
+  current_targets t
+  >>= fun targets ->
+  let list_of_ids =
+    match query with
+    | `All -> List.map targets ~f:Ketrew_target.id
+    | `Not_finished_before time ->
+      List.filter_map targets ~f:(fun t ->
+          let st = Ketrew_target.state t in
+          match Ketrew_target.State.history st with
+          | `Finished {Ketrew_gen_target_v0.History.log; _}
+            when log.Ketrew_gen_target_v0.Log.time < time -> None
+          | _ -> Some (Ketrew_target.id t))
+  in
+  return list_of_ids
+
 let kill t ~id =
   Killing_targets.add_target_ids_to_kill_list t [id]
 

--- a/src/lib/ketrew_engine.ml
+++ b/src/lib/ketrew_engine.ml
@@ -803,7 +803,7 @@ let get_status t id =
   get_target t id >>= fun target ->
   return (Target.state target) 
 
-let get_list_of_ids t query =
+let get_list_of_target_ids t query =
   current_targets t
   >>= fun targets ->
   let list_of_ids =

--- a/src/lib/ketrew_engine.mli
+++ b/src/lib/ketrew_engine.mli
@@ -88,7 +88,12 @@ val current_targets :
     | `Target of [> `Deserilization of string ] ])
   Deferred_result.t
 (** Get the list of targets currently handled. *)
-  
+
+val get_list_of_ids: t -> [ `All | `Not_finished_before of Time.t ] ->
+  (Ketrew_target.id list,
+   [> `Database of Trakeva.Error.t
+   | `Target of [> `Deserilization of string ] ]) Deferred_result.t
+
 module Run_automaton : sig
   val step :
     t ->

--- a/src/lib/ketrew_engine.mli
+++ b/src/lib/ketrew_engine.mli
@@ -89,10 +89,15 @@ val current_targets :
   Deferred_result.t
 (** Get the list of targets currently handled. *)
 
-val get_list_of_ids: t -> [ `All | `Not_finished_before of Time.t ] ->
+val get_list_of_target_ids: t -> [ `All | `Not_finished_before of Time.t ] ->
   (Ketrew_target.id list,
    [> `Database of Trakeva.Error.t
    | `Target of [> `Deserilization of string ] ]) Deferred_result.t
+(** Get only the Ids of the targets for a given “query”:
+    
+- [`All] for all the targets visible to the engine.
+- [`Not_finished_before _] for the targets that were not finished at a given date.
+*)
 
 module Run_automaton : sig
   val step :

--- a/src/lib/ketrew_explorer.ml
+++ b/src/lib/ketrew_explorer.ml
@@ -35,6 +35,8 @@ module Target_cache  = struct
     Hashtbl.replace targets id value;
     return ()
 
+  let clear {targets} = Hashtbl.clear targets
+
 end
 
 type exploration_state = {
@@ -76,6 +78,7 @@ let reload_list_of_ids explorer =
   Log.(s "Explorer.reload got " % i (List.length id_list) % s " ids"
        @ verbose);
   explorer.target_ids <- id_list;
+  Target_cache.clear explorer.target_cache;
   return ()
 
 let get_target ?(force_reload=false) explorer ~id =

--- a/src/lib/ketrew_explorer.ml
+++ b/src/lib/ketrew_explorer.ml
@@ -20,9 +20,15 @@ module Document = Ketrew_document
 module Interaction = Ketrew_interaction
 
 module Target_cache  = struct
+  (**
+     For now we implement the cache with a [Hashtbl.t] but in the
+     future this maybe using a proper DB or cache. Hence the I/O types
+     ([Deferred_result.t]) given to the functions. *)
+
   type t = {
-    targets: (string, Target.t) Hashtbl.t;
+    targets: (Target.id, Target.t) Hashtbl.t;
   }
+
   let create () = {targets = Hashtbl.create 42}
 
   let get {targets} ~id =

--- a/src/lib/ketrew_explorer.mli
+++ b/src/lib/ketrew_explorer.mli
@@ -18,11 +18,11 @@ open Ketrew_pervasives
 
 (** The “Target Explorer™“ *)
 
-type exploration_state
+type t
 
-val explore : client:[< `Http_client of Ketrew_client.Http_client.t
-                     | `Standalone of Ketrew_client.Standalone.t & 'a ] ->
-              exploration_state list ->
+val create : client:Ketrew_client.t -> unit -> t
+
+val explore : t ->
   (unit, [> `Client of
             [> `Http of
               [> `Archive_targets of string list
@@ -45,6 +45,6 @@ val explore : client:[< `Http_client of Ketrew_client.Http_client.t
         | `Missing_data of string
         | `Persistent_state of [> `Deserilization of string ]
         | `System of [> `File_info of string ] * [> `Exn of exn ]
-        | `Target of [> `Deserilization of string ] ]) t
+        | `Target of [> `Deserilization of string ] ]) Deferred_result.t
 (** [explore ~client exploration_states] runs a read-eval loop to explore and
     interact with targets.*)

--- a/src/lib/ketrew_server.ml
+++ b/src/lib/ketrew_server.ml
@@ -236,6 +236,11 @@ let do_action_on_ids ~server_state ~ids (what_to_do: [`Kill  | `Restart]) =
   Light.green server_state.loop_traffic_light;
   return (`Message (`Json, `Ok))
 
+let answer_get_target_ids ~server_state query =
+  Ketrew_engine.get_list_of_ids server_state.state query
+  >>= fun list_of_ids ->
+  return (`Message (`Json, `List_of_target_ids list_of_ids))
+
 let api_service ~server_state ~body req =
   get_post_body req ~body
   >>= fun body ->
@@ -269,6 +274,10 @@ let api_service ~server_state ~body req =
     with_capability `Restart_targets
     >>= fun () ->
     do_action_on_ids ~server_state ~ids `Restart
+  | `Get_target_ids query ->
+    with_capability `See_targets
+    >>= fun () ->
+    answer_get_target_ids ~server_state query
   end
 
 (** {2 Dispatcher} *)

--- a/src/lib/ketrew_server.ml
+++ b/src/lib/ketrew_server.ml
@@ -237,7 +237,7 @@ let do_action_on_ids ~server_state ~ids (what_to_do: [`Kill  | `Restart]) =
   return (`Message (`Json, `Ok))
 
 let answer_get_target_ids ~server_state query =
-  Ketrew_engine.get_list_of_ids server_state.state query
+  Ketrew_engine.get_list_of_target_ids server_state.state query
   >>= fun list_of_ids ->
   return (`Message (`Json, `List_of_target_ids list_of_ids))
 


### PR DESCRIPTION

The idea is that now the text-based target browser carries around a cache of the information and it updates it only when needed or explicitly requested.

This is related to https://github.com/hammerlab/ketrew/issues/65.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/126)
<!-- Reviewable:end -->
