### PR TITLE
Add mb as yarn memory option

### DIFF
--- a/src/atd/yarn_v0.atd
+++ b/src/atd/yarn_v0.atd
@@ -26,7 +26,7 @@ type daemonized_run <ocaml from="Ketrew_gen_daemonize_v0.Running"> = abstract
 type distributed_shell_parameters = {
   hadoop_bin: string;
   distributed_shell_shell_jar: string;
-  container_memory: [ GB of int | Raw of string ];
+  container_memory: [ GB of int | MB of int | Raw of string ];
   timeout: [ Seconds of int | Raw of string ];
   application_name: string;
 }

--- a/src/lib/pure/ketrew_edsl.mli
+++ b/src/lib/pure/ketrew_edsl.mli
@@ -277,7 +277,7 @@ val yarn_distributed_shell :
   ?daemon_start_timeout:float ->
   ?hadoop_bin:string ->
   ?distributed_shell_shell_jar:string ->
-  container_memory:[ `GB of int | `Raw of string ] ->
+  container_memory:[ `GB of int | `MB of int | `Raw of string ] ->
   timeout:[ `Raw of string | `Seconds of int ] ->
   application_name:string ->
   Ketrew_program.t -> [> `Long_running of string * string ]

--- a/src/lib/pure/ketrew_yarn.ml
+++ b/src/lib/pure/ketrew_yarn.ml
@@ -73,6 +73,7 @@ let log =
         "Container Memory",
         (match container_memory with
          | `GB gb -> sf "%d GB" gb
+         | `MB mb -> sf "%d MB" mb
          | `Raw raw -> sf "%S" raw);
         "Timeout",
         (match timeout with
@@ -184,6 +185,7 @@ let start = function
       let container_memory =
         match container_memory with
         | `GB i -> fmt "%d" (i * 1024)
+        | `MB i -> fmt "%d" i
         | `Raw s -> s
       in
       let timeout =

--- a/src/lib/pure/ketrew_yarn.mli
+++ b/src/lib/pure/ketrew_yarn.mli
@@ -30,7 +30,7 @@ open Ketrew_gen_yarn_v0
 val distributed_shell_program :
   ?hadoop_bin:string ->
   ?distributed_shell_shell_jar:string ->
-  container_memory:[ `GB of int | `Raw of string ] ->
+  container_memory:[ `GB of int | `MB of int | `Raw of string ] ->
   timeout:[ `Raw of string | `Seconds of int ] ->
   application_name:string ->
   Ketrew_program.t ->


### PR DESCRIPTION
This does build and I think I covered everything, but when running with biokepi and submitting, I get the following error

```
        * ID: ketrew_2015-03-26-15h32m10s605ms-UTC_754955217
        * Dependencies: [ ]
        * Fallbacks: [ ]
        * On Success trigger: [ ]
        * Metadata: None
        * Build-process: Long-running (yarn-cluster):
            Error: Serialization exception: CConv.ConversionFailure("conversion
            error: unexpected variant name: \"MB\"")
```

Does this have to do with client/server being out of sync?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/136)
<!-- Reviewable:end -->
