### PR TITLE
Set `OCAMLPARAM` to `warn-error=A` for the travis script

### DIFF
--- a/tools/travis_ci_test.sh
+++ b/tools/travis_ci_test.sh
@@ -97,6 +97,9 @@ ocamlfind list | grep cohttp
 echo "Sqlite version"
 sqlite3 -version
 
+echo "Setting Warn-Error for the Travis test"
+export OCAMLPARAM="warn-error=A,_"
+
 echo "Test-trakeva"
 git clone  git://github.com/smondet/trakeva
 cd trakeva


### PR DESCRIPTION

With this, we ask Travis to fail on warnings for compiling Trakeva and Ketrew.

See this branch:
https://github.com/hammerlab/ketrew/tree/test_travis_warning
it adds a deprecated functions, that makes a warning in 4.02.x:
https://travis-ci.org/hammerlab/ketrew/builds/55986306



<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/137)
<!-- Reviewable:end -->
