### PR TITLE
Move serialization to PPX

### DIFF
--- a/src/lib/ketrew_eval_condition.ml
+++ b/src/lib/ketrew_eval_condition.ml
@@ -84,30 +84,30 @@ end
 
 open Ketrew_target.Condition
 
-  let rec eval = 
-    function
-    | `Satisfied -> return true
-    | `Never -> return false
-    | `Volume_exists v -> Volume.exists v
-    | `Volume_size_bigger_than (v, sz) ->
-      Volume.get_size v
-      >>= fun size ->
-      return (size >= sz)
-    | `Command_returns (c, ret) ->
-      Command.get_return_value c  
-      >>= fun return_value ->
-      return (ret = return_value)
-    | `And list_of_conditions -> 
-      (* Should start at the first that returns `false` *)
-      let rec go = function
-      | [] -> return true
-      | cond :: rest ->
-        eval cond
-        >>= function
-        | true -> go rest
-        | false -> return false
-      in
-      go list_of_conditions
+let rec eval = 
+  function
+  | `Satisfied -> return true
+  | `Never -> return false
+  | `Volume_exists v -> Volume.exists v
+  | `Volume_size_bigger_than (v, sz) ->
+    Volume.get_size v
+    >>= fun size ->
+    return (size >= sz)
+  | `Command_returns (c, ret) ->
+    Command.get_return_value c  
+    >>= fun return_value ->
+    return (ret = return_value)
+  | `And list_of_conditions -> 
+    (* Should start at the first that returns `false` *)
+    let rec go = function
+    | [] -> return true
+    | cond :: rest ->
+      eval cond
+      >>= function
+      | true -> go rest
+      | false -> return false
+    in
+    go list_of_conditions
 
 let bool = eval
   


### PR DESCRIPTION

This started as an experiment around issue [`#125`](https://github.com/hammerlab/ketrew/issues/125).

It solves half of issue [`#123`](https://github.com/hammerlab/ketrew/issues/123).

To compile/work this requires pinning to the master branch of [`ppx_deriving_yojson`](https://github.com/whitequark/ppx_deriving_yojson/) (so that the PR [`#25`](https://github.com/whitequark/ppx_deriving_yojson/pull/25) fix for issue [`#24`](https://github.com/whitequark/ppx_deriving_yojson/issues/24) is in use).

Thanks to `ppx_blob` the work of `tools/please.ml` has been simplified quite a lot; we could get of it later by getting the full `_oasis` file as a blob and writing the git version from the `Makefile`.

The libraries `ketrew_pure` and `ketrew` have more meaning now; see their dependencies:

```ocaml
let pure_findlib_packages = [
  "sosa"; "nonstd"; "docout"; "pvem"; "yojson"; "uri"; "toml";
  "cohttp"; (* → measurements refer to cohttp “pure” lib *)
  "ppx_deriving_yojson"; "ppx_deriving.show"; "ppx_blob";
]
let unix_findlib_packages = [
  "threads"; "trakeva_sqlite"; "pvem_lwt_unix"; "cmdliner"; "cohttp.lwt"; "lwt";
  "ssl"; "conduit"; "dynlink"; "findlib";
]
```

→ After getting rid of Toml, I may try demoing a `js_of_ocaml` client :)

The interface leak much less now also (i.e. more types that should be abstract are abstract).

--------------------------------------------------------------------------------

It's a huge PR, so please do not use reviewable, and look at the commits. They move parts of the code base to PPX progressively while keeping backwards compatibility until we can get rid of ATD.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/142)
<!-- Reviewable:end -->
