### PR TITLE
[RFC] Add a typed and extensible API to the EDSL

### DIFF
--- a/src/lib/ketrew_edsl.mli
+++ b/src/lib/ketrew_edsl.mli
@@ -199,6 +199,7 @@ val file_target:
   user_target
 (** Create a file {!user_artifact} and the {!user_target} that produces it. *)
 
+
 val daemonize :
   ?starting_timeout:float ->
   ?call_script:(string -> string list) ->
@@ -294,3 +295,37 @@ val yarn_distributed_shell :
       can fail if this string contains spaces for example).
 
 *)
+
+(** {2 Typed & Extensible API}
+
+    More advanced and safer.
+
+*)
+
+type single_file = <
+  exists: Ketrew_target.Condition.t;
+  is_done: Ketrew_target.Condition.t option;
+  path : string;
+  is_bigger_than: int -> Ketrew_target.Condition.t;
+>
+val single_file: ?host:Host.t -> string -> single_file
+
+val nothing:  < is_done : Ketrew_target.Condition.t option >
+
+type 'product step = <
+  product : 'product;
+  target: user_target;
+> constraint 'product = < is_done : Ketrew_target.Condition.t option ; .. >
+
+val step :
+  ?active:bool ->
+  ?depends_on:_ step list ->
+  ?make:Ketrew_target.Build_process.t ->
+  ?done_when:Ketrew_target.Condition.t ->
+  ?metadata:[ `String of string ] ->
+  ?equivalence:Ketrew_target.Equivalence.t ->
+  ?on_failure_activate:_ step list ->
+  ?on_success_activate:_ step list ->
+  ?tags:string list ->
+  ?name:string ->
+  (< is_done : Ketrew_target.Condition.t option; .. > as 'product) -> 'product step


### PR DESCRIPTION
This proposal is backwards compatible and beginner friendly: it just adds a new more high-level construct that is more “typed” (products show up in the type parameter) and extensible (any object with an `is_done` method can be a product).

I'm not sure about the name `step`, it's the only thing I could find.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/182)
<!-- Reviewable:end -->