### PR TITLE
Updated the repo URL to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ any Unix platform.
 
 If you have `opam` up and running:
 
-    opam remote add smondet git@github.com:smondet/dev-opam-repo.git
+    opam remote add -k git smondet https://github.com/smondet/dev-opam-repo
     opam install ketrew
 
 Then you need at runtime `ssh` in the `$PATH`.


### PR DESCRIPTION
Public access to GitHub repositories should be made over HTTPS, not SSH.
More info: https://help.github.com/articles/which-remote-url-should-i-use/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/183)
<!-- Reviewable:end -->
