### PR TITLE
Cohttp 0.18.0 compatibility

### DIFF
--- a/src/lib/ketrew_client.ml
+++ b/src/lib/ketrew_client.ml
@@ -32,7 +32,7 @@ module Error = struct
         | `Json_parsing of string * [ `Exn of exn ]
         | `Unexpected_message of Ketrew_protocol.Down_message.t
         | `Wrong_json of Yojson.Safe.json
-        | `Wrong_response of Cohttp_lwt_unix.Client.Response.t * string ]
+        | `Wrong_response of Cohttp.Response.t * string ]
     | `Server_error_response of
         [ `Call of [ `GET | `POST ] * Uri.t ] * string ]
 
@@ -100,7 +100,7 @@ module Http_client = struct
     wrap_deferred ~on_exn:(fun e -> client_error ~where ~what:(`Exn e))
       (fun () -> Cohttp_lwt_body.to_string body)
     >>= fun body_str ->
-    begin match Cohttp_lwt_unix.Client.Response.status response with
+    begin match Cohttp.Response.status response with
     | `OK ->
       begin try
         return (Yojson.Safe.from_string body_str)

--- a/src/lib/ketrew_client.mli
+++ b/src/lib/ketrew_client.mli
@@ -40,7 +40,7 @@ module Error : sig
         | `Json_parsing of string * [ `Exn of exn ]
         | `Unexpected_message of Ketrew_protocol.Down_message.t
         | `Wrong_json of Yojson.Safe.json
-        | `Wrong_response of Cohttp_lwt_unix.Client.Response.t * string ]
+        | `Wrong_response of Cohttp.Response.t * string ]
     | `Server_error_response of
         [ `Call of [ `GET | `POST ] * Uri.t ] * string ]
 

--- a/src/lib/ketrew_error.ml
+++ b/src/lib/ketrew_error.ml
@@ -49,7 +49,7 @@ let log_client_error error_value =
       | `Wrong_response (http_resp, body) ->
         s "Returned:" % n % 
         indent (s "Response: "
-                % sexp Cohttp_lwt_unix.Client.Response.sexp_of_t http_resp)
+                % sexp Cohttp.Response.sexp_of_t http_resp)
         % n
         % indent (s "Body: " % quote body)
       | `Json_parsing (j, `Exn e) ->

--- a/src/lib/ketrew_server.ml
+++ b/src/lib/ketrew_server.ml
@@ -141,20 +141,20 @@ type answer = [
 type 'error service =
   server_state:Server_state.t ->
   body:Cohttp_lwt_body.t ->
-  Cohttp_lwt_unix.Server.Request.t ->
+  Cohttp.Request.t ->
   (answer, 'error) Deferred_result.t
 (** A service is something that replies an [answer] on a ["/<path>"] URL. *)
 
 (** Get the ["token"] parameter from an URI. *)
 let token_parameter req =
   let token =
-    Uri.get_query_param (Cohttp_lwt_unix.Server.Request.uri req) "token" in
+    Uri.get_query_param (Cohttp.Request.uri req) "token" in
   Log.(s "Got token: " % OCaml.option quote token @ very_verbose);
   token
 
 (** Get a parameter or fail. *)
 let mandatory_parameter req ~name =
-  match Uri.get_query_param (Cohttp_lwt_unix.Server.Request.uri req) name with
+  match Uri.get_query_param (Cohttp.Request.uri req) name with
   | Some v ->
     Log.(s "Got " % quote name % s ": " % quote v @ very_verbose);
     return v
@@ -171,7 +171,7 @@ let format_parameter req =
 
 (** Fail if the request is not a [`GET]. *)
 let check_that_it_is_a_get request =
-  begin match Cohttp_lwt_unix.Server.Request.meth request with
+  begin match Cohttp.Request.meth request with
   | `GET ->
     Log.(s "It is a GET request" @ very_verbose);
     return ()
@@ -180,7 +180,7 @@ let check_that_it_is_a_get request =
 
 (** Check that it is a [`POST], get the {i non-empty} body; or fail. *)
 let get_post_body request ~body =
-  begin match Cohttp_lwt_unix.Server.Request.meth request with
+  begin match Cohttp.Request.meth request with
   | `POST ->
     Log.(s "It is a GET request" @ very_verbose);
     wrap_deferred ~on_exn:(fun e -> `IO (`Exn e))
@@ -307,9 +307,9 @@ let api_service ~server_state ~body req =
 (** {2 Dispatcher} *)
 
 let handle_request ~server_state ~body req : (answer, _) Deferred_result.t =
-  Log.(s "Request-in: " % sexp Cohttp_lwt_unix.Server.Request.sexp_of_t req
+  Log.(s "Request-in: " % sexp Cohttp.Request.sexp_of_t req
        @ verbose);
-  match Uri.path (Cohttp_lwt_unix.Server.Request.uri req) with
+  match Uri.path (Cohttp.Request.uri req) with
   | "/hello" -> return `Unit
   | "/api" -> api_service ~server_state ~body req
   | other ->

--- a/src/lib/ketrew_server.mli
+++ b/src/lib/ketrew_server.mli
@@ -45,7 +45,7 @@ val start: configuration:Ketrew_configuration.server ->
 val status: configuration:Ketrew_configuration.server ->
   ([ `Not_responding of string
    | `Running
-   | `Wrong_response of Cohttp_lwt_unix.Client.Response.t ],
+   | `Wrong_response of Cohttp.Response.t ],
    [> `Failure of string | `Server_status_error of string ]) Deferred_result.t
 (** Ask for the status of the server running locally by calling
     ["https://127.0.0.1:<port>/hello"]. *)


### PR DESCRIPTION
Use Request/Response directly from Cohttp base module. The lwt specific
versions have been removed in cohttp 0.18.0 since they were the same
anyway.

I think this should make ketrew compatible with 0.17.0 and 0.18.0

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/186)
<!-- Reviewable:end -->
