### PR TITLE
Add a .ocamlinit generating omake target

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -27,7 +27,7 @@ else
     echo "Not using Bisect: " $(getenv WITH_BISECT, "")
     BISECT_PACKAGE=
     export
- 
+
 PURE_LIB_PACKAGES = sosa nonstd docout pvem yojson uri cohttp \
    ppx_deriving_yojson ppx_deriving.show $(BISECT_PACKAGE) react reactiveData
 
@@ -146,4 +146,7 @@ bisect-report: _report_dir
                       -I _build/ketrew-test \
                       -I _build/ketrew-workflow-examples \
                       -verbose -html _report_dir  bisect*.out
-    
+
+DIRS[] = src/pure src/lib
+LIBS[] = ketrew_pure ketrew
+DotOCamlinit($(DIRS), $(LWT_UNIX_LIB_PACKAGES), $(LIBS))

--- a/tools/OMakeLibrary.om
+++ b/tools/OMakeLibrary.om
@@ -134,9 +134,19 @@ public.OCamlProgramOfFile(appname, path) =
 
 public.DotMerlin(topdir, packages) =
     .merlin:
-         rm -f .merlin
-         foreach(d => ..., $(find $(topdir) -d {}))
-              echo "S $(d)" >> $@
-              echo "B _build/$(d)" >> $@
-         foreach(m => ..., $(packages))
-              echo "PKG $(m)" >> $@
+        rm -f .merlin
+        foreach(d => ..., $(find $(topdir) -d {}))
+            echo "S $(d)" >> $@
+            echo "B _build/$(d)" >> $@
+        foreach(m => ..., $(packages))
+            echo "PKG $(m)" >> $@
+
+public.DotOCamlinit(dirs, packages, to_load) =
+    .ocamlinit:
+        rm -f $@
+        foreach(d => ..., $(dirs))
+            echo "#directory \"_build/$(d)\"" >> $@
+        foreach(m => ..., $(packages))
+            echo "#require \"$(m)\"" >> $@
+        foreach(m => ..., $(to_load))
+            echo "#load_rec \"$(m).cma\"" >> $@


### PR DESCRIPTION
Now the wonders of `$omake .ocamlinit` should create a `.ocamlinit` in the source directory, for those people who use repls.

Actually, it isn't all that automatic. Since I hard coded the values for `DIRS[]` and `LIBS[]` at the bottom. I did this for 2 reasons. 

1. Don't have the brainwidth to load `Omake` at the moment and 
2. Loading everything (including the `js` stuff) will fail with 
     
      ```Unimplemented Javascript primitive caml_pure_js_expr!```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/232)
<!-- Reviewable:end -->
