### PR TITLE
Uri pct encode the token as query value

### DIFF
--- a/src/client-joo/protocol_client.ml
+++ b/src/client-joo/protocol_client.ml
@@ -63,6 +63,8 @@ let name {name; _} = name
 
 let jsonp_of_raw_url ~name url = create ~name (JSONP url)
 
+let encode_uri_value = Uri.pct_encode ~component:`Query_key
+
 let jsonp_call url =
   (fun msg callback_name ->
      fmt "%s&callback=%s&message=%s"
@@ -75,7 +77,7 @@ let jsonp_of_url ~protocol ~host ?port ~token () =
     Printf.sprintf  "%s//%s%s/apijsonp?token=%s"
       protocol host
       (Option.value_map port ~f:(fmt ":%d") ~default:"")
-      token
+      (encode_uri_value token)
   in
   jsonp_of_raw_url url
 
@@ -131,7 +133,7 @@ let of_current () : t option =
 let base_url {connection; _} =
   match connection with
   | JSONP url -> url
-  | XHR (`Token tok)  -> fmt "/api?token=%s" tok
+  | XHR (`Token tok)  -> fmt "/api?token=%s" (encode_uri_value tok)
 
 
 let of_window_object () =

--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -648,8 +648,9 @@ let cmdliner_main ?override_configuration ?argv ?(additional_commands=[]) () =
               | `Client c ->
                 let url = Configuration.connection c in
                 let token = Configuration.token c in
+                let encoded_tok = Uri.pct_encode ~component:`Query_key token in
                 System.Shell.do_or_fail
-                  (fmt "%s %s/gui?token=%s" open_cmd url token)
+                  (fmt "%s %s/gui?token=%s" open_cmd url encoded_tok)
             )
           $ configuration_arg
           $ Arg.(value @@ opt string "open"


### PR DESCRIPTION
The first commit fixes #231 

But I'm not sure if this is the complete fix. Specifically, I'm not certain that I've covered all of the communication points between the web client and server. Lastly, I'm confused by why [Ocaml-uri](https://github.com/mirage/ocaml-uri) calls this a `key` as it seems to be a `value` to me.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/238)
<!-- Reviewable:end -->
