### PR TITLE
Fix ordering of flattened states (#264)

### DIFF
--- a/src/pure/target.mli
+++ b/src/pure/target.mli
@@ -200,6 +200,7 @@ module State : sig
       message: string option;
       more_info: string list;
       finished: bool;
+      depth: int;
     } [@@deriving yojson]
 
     val time: item ->  float


### PR DESCRIPTION

Submitted a target with a client-side-clock advancing 5 minutes, the displayed order/status is still right:
<img width="359" alt="screenshot 2015-11-11 15 52 51" src="https://cloud.githubusercontent.com/assets/617111/11102726/4f008192-888c-11e5-8480-3c4a94bec576.png">


This makes the protocol non-backwards compatible for a computed (non-stored) value, if a user restarts with the newer version, they'll have to reload the WebUI page :)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/268)
<!-- Reviewable:end -->
