### PR TITLE
Mass killing UI

### DIFF
--- a/src/client-joo/single_client.ml
+++ b/src/client-joo/single_client.ml
@@ -716,9 +716,11 @@ let restart_target t ~id ~on_result =
   call_unit_message t ~id ~on_result
     ~name:"restart" ~message:(`Restart_targets [id])
 
+let kill_targets t ~ids ~on_result =
+  call_unit_message t ~id:(String.concat ~sep:"-" ids) ~on_result
+    ~name:"kill" ~message:(`Kill_targets ids)
 let kill_target t ~id ~on_result =
-  call_unit_message t ~id ~on_result
-    ~name:"kill" ~message:(`Kill_targets [id])
+  kill_targets t ~ids:[id] ~on_result
 
 module Html = struct
 
@@ -1046,6 +1048,7 @@ module Html = struct
                       |> Signal.map ~f:(function
                         | `Target_table ->
                           Target_table.Html.render client.target_table
+                            ~kill_targets:(kill_targets client)
                             ~get_target:(fun id ->
                                 Target_cache.get_target_summary_signal
                                   client.target_cache ~id)

--- a/src/client-joo/single_client.ml
+++ b/src/client-joo/single_client.ml
@@ -417,13 +417,15 @@ let start_list_of_ids_loop t =
             ]
           );
         begin if first_time && not and_block then
-            Target_table.set_filter_results_number t.target_table (List.length l)
+            Target_table.modify_filter_results_number t.target_table
+              (fun _ -> List.length l)
         end;
         Target_table.add_target_ids ?server_time t.target_table l;
         return ()
       | `Deferred_list_of_target_ids (answer_id, big) ->
         begin if first_time && not and_block then
-            Target_table.set_filter_results_number t.target_table big;
+            Target_table.modify_filter_results_number t.target_table
+              (fun _ -> big);
         end;
         get_ids false (`Get_deferred (answer_id, 0, min 100 big))
       | other ->

--- a/src/client-joo/target_table.ml
+++ b/src/client-joo/target_table.ml
@@ -477,6 +477,9 @@ let visible_target_ids t =
           Some ids)
   )
 
+let modify_filter_results_number t f =
+  Reactive.Source.modify t.filter_results_number f
+
 let add_target_ids t ?server_time l =
   let current =
     Reactive.(Source.signal t.target_ids |> Signal.value)
@@ -486,12 +489,13 @@ let add_target_ids t ?server_time l =
   | Some s -> Reactive.Source.set t.target_ids_last_updated (Some s)
   | None -> ()
   end;
-  Reactive.Source.set t.target_ids
-    (Some (Target_id_set.add_list current l));
+  let new_one = Target_id_set.add_list current l in
+  Reactive.Source.set t.target_ids (Some new_one);
+  modify_filter_results_number t (fun current ->
+      max current (Target_id_set.length new_one)
+    );
   ()
 
-let set_filter_results_number t n =
-  Reactive.Source.set t.filter_results_number n
 
 module Html = struct
 

--- a/src/client-joo/target_table.mli
+++ b/src/client-joo/target_table.mli
@@ -35,6 +35,10 @@ module Html: sig
   val title: t -> [> Html5_types.span ] Reactive_html5.H5.elt
 
   val render :
+    kill_targets:(
+      ids: string list ->
+      on_result:([ `Error of string | `Ok of unit ] -> unit) ->
+      unit) ->
     get_target:(bytes ->
                 Local_cache.Target_cache.target_knowledge
                   Reactive.signal) ->

--- a/src/client-joo/target_table.mli
+++ b/src/client-joo/target_table.mli
@@ -20,7 +20,7 @@ val add_target_ids:
   ?server_time:Ketrew_pure.Internal_pervasives.Time.t ->
   string list -> unit
 
-val set_filter_results_number: t -> int -> unit
+val modify_filter_results_number: t -> (int -> int) -> unit
 
 val visible_target_ids: t -> string list option Reactive.Signal.t
 

--- a/src/doc/Developer_Documentation.md
+++ b/src/doc/Developer_Documentation.md
@@ -176,6 +176,16 @@ To remove the instrumentation just use `omake clean; omake` without
 Bisect (You'll see errors in the JS-Console: “`caml_mutex_new` not
 implemented”).
 
+### Slow Down The Server
+
+In order to test the WebUI in more adverse conditions, the server can be asked
+to answer HTTP queries artificially slow:
+
+    KETREW_DEBUG_SLOW_SERVER=1.,0.5 kdserver start
+
+The 2 floating-point numbers `x,y` mean that, at each HTTP request, the server
+will pause for `Random.float x +. y` seconds.
+
 How to Release
 --------------
 


### PR DESCRIPTION

This add a button to the target table that can allow to attempt to kill all the currently visible targets.

The restriction is the same as the one of the table, if the filter  gives too many results we don't have the information to call `` `Kill_targets _``. For now we just disable it, playing with the full results of a query-filter will come with a later refactoring of the WebUI code.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/271)
<!-- Reviewable:end -->
