### PR TITLE
Fix compilation with `-safe-string`

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -37,7 +37,7 @@ LWT_UNIX_LIB_PACKAGES = $(PURE_LIB_PACKAGES) threads trakeva_of_uri \
 JOO_PACKAGES = $(PURE_LIB_PACKAGES) js_of_ocaml js_of_ocaml.ppx js_of_ocaml.tyxml
 
 
-OCAMLFLAGS = -bin-annot -thread -short-paths -g -strict-formats -strict-sequence -w +9
+OCAMLFLAGS = -bin-annot -thread -short-paths -g -strict-formats -strict-sequence -w +9 -safe-string
 
 section # Pure library
     OCAMLPACKS[] = $(PURE_LIB_PACKAGES)

--- a/src/client-joo/protocol_client.mli
+++ b/src/client-joo/protocol_client.mli
@@ -22,8 +22,8 @@ val call :
   (Ketrew_pure.Protocol.Down_message.t,
    [> `Protocol_client of
         [> `JSONP of [> `Exn of exn | `Timeout ]
-        | `Parsing_message of bytes * exn
-        | `Wrong_xhr_status of int * bytes
+        | `Parsing_message of string * exn
+        | `Wrong_xhr_status of int * string
         | `Xhr_timeout
         ] ])
     Pvem_js.t
@@ -35,7 +35,7 @@ module Error: sig
       | `JSONP of
           [< `Exn of exn | `Timeout ]
       | `Parsing_message of string * exn
-      | `Wrong_xhr_status of int * bytes 
+      | `Wrong_xhr_status of int * string 
       | `Xhr_timeout
     ] ->
     string

--- a/src/client-joo/target_page.ml
+++ b/src/client-joo/target_page.ml
@@ -47,7 +47,7 @@ type t = {
   reload_query_result: query:string -> unit;
   reload_available_queries: unit -> unit;
   get_query_result: query:string ->
-    [ `Error of bytes | `None | `String of (Time.t * bytes) ] Reactive.Signal.t;
+    [ `Error of string | `None | `String of (Time.t * string) ] Reactive.Signal.t;
 }
 let create ~target_cache ~id
     ~restart_target ~kill_target ~target_link_on_click_handler

--- a/src/client-joo/target_page.mli
+++ b/src/client-joo/target_page.mli
@@ -11,10 +11,10 @@ val create:
   reload_query_result:(query:string -> unit) ->
   available_queries:Local_cache.Target_cache.query_description
       Reactive.Signal.t ->
-  get_query_result:(query:bytes ->
-                    [ `Error of bytes
+  get_query_result:(query:string ->
+                    [ `Error of string
                     | `None
-                    | `String of float * bytes ] Reactive.signal) ->
+                    | `String of float * string ] Reactive.signal) ->
   t
 
 val eq: t -> t -> bool

--- a/src/client-joo/target_table.mli
+++ b/src/client-joo/target_table.mli
@@ -39,11 +39,11 @@ module Html: sig
       ids: string list ->
       on_result:([ `Error of string | `Ok of unit ] -> unit) ->
       unit) ->
-    get_target:(bytes ->
+    get_target:(string ->
                 Local_cache.Target_cache.target_knowledge
                   Reactive.signal) ->
-    target_link_on_click:(bytes -> unit) ->
-    get_target_status:(bytes ->
+    target_link_on_click:(string -> unit) ->
+    get_target_status:(string ->
                        Ketrew_pure.Target.State.Flat.t Reactive.signal) ->
     t -> [> Html5_types.div ] Reactive_html5.H5.elt
 end

--- a/src/lib/client.mli
+++ b/src/lib/client.mli
@@ -55,14 +55,14 @@ val as_client:
   f:(client:t ->
      (unit,
       [> `Database of Trakeva.Error.t
-      | `Database_unavailable of bytes
+      | `Database_unavailable of string
       | `Dyn_plugin of
            [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
-      | `Failure of bytes
-      | `Missing_data of bytes
-      | `Target of [> `Deserilization of bytes ]
+      | `Failure of string
+      | `Missing_data of string
+      | `Target of [> `Deserilization of string ]
       | `Wrong_configuration of
-           [> `Found of bytes ] * [> `Exn of exn ] ]
+           [> `Found of string ] * [> `Exn of exn ] ]
       as 'a)
        Deferred_result.t) ->
   (unit, 'a) Deferred_result.t
@@ -84,7 +84,7 @@ val all_targets: t ->
   (Ketrew_pure.Target.t list,
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `IO of
         [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
    | `Missing_data of Ketrew_pure.Target.id
@@ -98,7 +98,7 @@ val get_list_of_target_ids : t ->
   (Ketrew_pure.Target.id list,
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
@@ -108,7 +108,7 @@ val get_target: t ->
   id:Ketrew_pure.Target.id ->
   (Ketrew_pure.Target.t,
    [> `Client of Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Database of Trakeva.Error.t
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ])
@@ -120,7 +120,7 @@ val get_targets: t ->
   (Ketrew_pure.Target.t list,
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ])
    Deferred_result.t

--- a/src/lib/engine.mli
+++ b/src/lib/engine.mli
@@ -31,9 +31,9 @@ val with_engine:
   (engine:t ->
    (unit, [> `Database of Trakeva.Error.t
           | `Failure of string
-          | `Missing_data of bytes
+          | `Missing_data of string
           | `Database_unavailable of Ketrew_pure.Target.id
-          | `Target of [> `Deserilization of bytes ]
+          | `Target of [> `Deserilization of string ]
           | `Dyn_plugin of
                [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
           ] as 'merge_error) Deferred_result.t) ->
@@ -44,10 +44,10 @@ val load:
   configuration:Configuration.engine ->
   (t,
    [> `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Failure of string
-   | `Missing_data of bytes
-   | `Target of [> `Deserilization of bytes ]
+   | `Missing_data of string
+   | `Target of [> `Deserilization of string ]
    | `Dyn_plugin of
         [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
    ]) Deferred_result.t
@@ -75,7 +75,7 @@ val add_targets :
 val get_target: t -> Unique_id.t ->
   (Ketrew_pure.Target.t,
    [> `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
@@ -85,7 +85,7 @@ val all_targets :
   t ->
   (Ketrew_pure.Target.t list,
    [> `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
     | `IO of
         [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
     | `Missing_data of Ketrew_pure.Target.id
@@ -98,7 +98,7 @@ val get_list_of_target_ids: t ->
   Ketrew_pure.Protocol.Up_message.target_query ->
   (Ketrew_pure.Target.id list,
    [> `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ]) Deferred_result.t
 (** Get only the Ids of the targets for a given “query”:
@@ -131,7 +131,7 @@ end
 val get_status : t -> Ketrew_pure.Target.id ->
   (Ketrew_pure.Target.State.t,
    [> `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `IO of
         [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
    | `Missing_data of string

--- a/src/lib/host_io.ml
+++ b/src/lib/host_io.ml
@@ -127,7 +127,7 @@ module Error = struct
        <host : string; stdout: string option; stderr: string option; message: string>
   | `System of [> `Sleep of float ] * [> `Exn of exn ]
   | `Timeout of float
-  | `Named_host_not_found of bytes
+  | `Named_host_not_found of string
   | `Ssh_failure of
        [> `Wrong_log of string
        | `Wrong_status of Unix_process.Exit_code.t ] * string ]

--- a/src/lib/host_io.mli
+++ b/src/lib/host_io.mli
@@ -47,7 +47,7 @@ module Error: sig
         [> `Wrong_log of string
         | `Wrong_status of Unix_process.Exit_code.t ] * string 
     | `System of [> `Sleep of float ] * [> `Exn of exn ]
-    | `Named_host_not_found of bytes
+    | `Named_host_not_found of string
     | `Timeout of float
   ]
 
@@ -74,7 +74,7 @@ module Error: sig
     | `Non_zero of string * int
     | `System of [ `Sleep of float ] * [ `Exn of exn ]
     | `Timeout of float
-    | `Named_host_not_found of bytes
+    | `Named_host_not_found of string
     | `Ssh_failure of
         [> `Wrong_log of string
         | `Wrong_status of Unix_process.Exit_code.t ] *
@@ -95,7 +95,7 @@ module Error: sig
     [< `Unix_exec of string
     | `Non_zero of (string * int)
     | `System of [< `Sleep of float ] * [< `Exn of exn ]
-    | `Named_host_not_found of bytes
+    | `Named_host_not_found of string
     | `Timeout of float
     | `Execution of
          < host : string; message : string; stderr : string option;
@@ -219,7 +219,7 @@ val get_file :
   path:Ketrew_pure.Path.t ->
   (string,
    [> `Cannot_read_file of string * string
-   | `Host of [> `Named_host_not_found of bytes ]
+   | `Host of [> `Named_host_not_found of string ]
    | `Timeout of Time.t ]) Deferred_result.t
 (** Read the file from the host at [path]. *)
 

--- a/src/lib/interaction.mli
+++ b/src/lib/interaction.mli
@@ -71,7 +71,7 @@ val build_sublist_of_targets :
     ([> `Cancel | `Go of string list ],
      [> `Client of Client.Error.t
       | `Database of Trakeva.Error.t
-      | `Database_unavailable of bytes
+      | `Database_unavailable of string
       | `Failure of string
       | `IO of [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
       | `Missing_data of string

--- a/src/lib/long_running_utilities.mli
+++ b/src/lib/long_running_utilities.mli
@@ -39,17 +39,17 @@ val classify_and_transform_errors :
    [< `Fatal of string
    | `Host of 
         [ `Execution of
-            < host : bytes; message : bytes; stderr : bytes option;
-              stdout : bytes option >
-        | `Named_host_not_found of bytes
-        | `Non_zero of bytes * int
+            < host : string; message : string; stderr : string option;
+              stdout : string option >
+        | `Named_host_not_found of string
+        | `Non_zero of string * int
         | `Ssh_failure of
-            [ `Wrong_log of bytes
+            [ `Wrong_log of string
             | `Wrong_status of Unix_process.Exit_code.t ] * 
-            bytes
+            string
         | `System of [ `Sleep of float ] * [ `Exn of exn ]
         | `Timeout of float
-        | `Unix_exec of bytes ]
+        | `Unix_exec of string ]
    | `IO of
         [< `Exn of exn
         | `File_exists of string
@@ -100,7 +100,7 @@ val get_log_of_monitored_script :
    | `Failure of string * string * string
    | `Start of string
    | `Success of string ] list option,
-   [> `Host of [> `Named_host_not_found of bytes ]
+   [> `Host of [> `Named_host_not_found of string ]
    | `Timeout of float ]) Deferred_result.t
 (** Fetch and parse the [log] file of a monitored-script. *)
 
@@ -109,7 +109,7 @@ val get_pid_of_monitored_script :
   host:Ketrew_pure.Host.t ->
   script:Ketrew_pure.Monitored_script.t ->
   (int option,
-   [> `Host of [> `Named_host_not_found of bytes ]
+   [> `Host of [> `Named_host_not_found of string ]
    | `Timeout of float ]) Deferred_result.t
 (** Fetch and parse the [pid] file of a monitored-script. *)
 

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -28,7 +28,7 @@ val create :
   database_parameters:string ->
   (t,
    [> `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
@@ -41,7 +41,7 @@ val get_target:
   Target.id ->
   (Ketrew_pure.Target.t,
    [> `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
@@ -50,7 +50,7 @@ val all_targets :
   t ->
   (Ketrew_pure.Target.t list,
    [>  `Database of Trakeva.Error.t
-   | `Database_unavailable of bytes
+   | `Database_unavailable of string
    | `Missing_data of string
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
@@ -148,17 +148,17 @@ module Synchronize: sig
     string ->
     (unit,
      [> `Database of Trakeva.Error.t
-     | `Database_unavailable of bytes
+     | `Database_unavailable of string
      | `IO of
-          [> `Read_file_exn of bytes * exn
-          | `Write_file_exn of bytes * exn ]
-     | `Missing_data of bytes
-     | `Not_a_directory of bytes
+          [> `Read_file_exn of string * exn
+          | `Write_file_exn of string * exn ]
+     | `Missing_data of string
+     | `Not_a_directory of string
      | `System of
-          [> `File_info of bytes
-          | `List_directory of bytes
-          | `Make_directory of bytes ] *
+          [> `File_info of string
+          | `List_directory of string
+          | `Make_directory of string ] *
           [> `Exn of exn | `Wrong_access_rights of int ]
-     | `Target of [> `Deserilization of bytes ] ])
+     | `Target of [> `Deserilization of string ] ])
       Deferred_result.t
 end

--- a/src/lib/process_holder.ml
+++ b/src/lib/process_holder.ml
@@ -291,7 +291,7 @@ We need to comunicate with that process:
 
 
   let read_fifo fifo =
-    let read_buffer = String.make 1 'B' in
+    let read_buffer = Bytes.make 1 'B' in
     wrap_deferred
       ~on_exn:(fun e -> `Failure (Printexc.to_string e)) (fun () ->
           let open Lwt in
@@ -305,7 +305,7 @@ We need to comunicate with that process:
             read fd read_buffer 0 1
             >>= function
             | 0 -> return None
-            | 1 -> return (Some (String.get_exn read_buffer 0))
+            | 1 -> return (Some (Bytes.get read_buffer 0))
             | more -> fail (Failure (fmt "read_char got %d bytes" more))
           in
           let rec read_all acc fd =

--- a/src/lib/process_holder.mli
+++ b/src/lib/process_holder.mli
@@ -60,15 +60,15 @@ module Ssh_connection : sig
     t ->
     (Ketrew_pure.Internal_pervasives.Display_markup.t, 'a) Deferred_result.t
   val write_to_fifo:
-    t -> bytes -> (unit, [> `Failure of bytes ]) Deferred_result.t
+    t -> string -> (unit, [> `Failure of string ]) Deferred_result.t
   val host_uri: t -> string
   val kill :
     t ->
     (unit,
-     [> `Failure of bytes
-     | `IO of [> `Read_file_exn of bytes * exn ]
+     [> `Failure of string
+     | `IO of [> `Read_file_exn of string * exn ]
      | `Shell of
-          bytes *
+          string *
           [> `Exited of int
           | `Exn of exn
           | `Signaled of int
@@ -91,10 +91,10 @@ val unload :
   t ->
   (unit,
    [> `List of
-        [> `Failure of bytes
-        | `IO of [> `Read_file_exn of bytes * exn ]
+        [> `Failure of string
+        | `IO of [> `Read_file_exn of string * exn ]
         | `Shell of
-             bytes *
+             string *
              [> `Exited of int
              | `Exn of exn
              | `Signaled of int

--- a/src/lib/server.mli
+++ b/src/lib/server.mli
@@ -33,18 +33,18 @@ val start: configuration:Configuration.server ->
    [> `Database of Trakeva.Error.t
    | `Dyn_plugin of
         [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
-   | `Failure of bytes
-   | `IO of [> `Read_file_exn of bytes * exn ]
-   | `Missing_data of bytes
-   | `Server_status_error of bytes
-   | `Start_server_error of bytes
-   | `Database_unavailable of bytes
+   | `Failure of string
+   | `IO of [> `Read_file_exn of string * exn ]
+   | `Missing_data of string
+   | `Server_status_error of string
+   | `Start_server_error of string
+   | `Database_unavailable of string
    | `System of
-        [> `File_info of bytes
-        | `List_directory of bytes
-        | `Remove of bytes ] *
+        [> `File_info of string
+        | `List_directory of string
+        | `Remove of string ] *
         [> `Exn of exn ]
-   | `Target of [> `Deserilization of bytes ] ]) Deferred_result.t
+   | `Target of [> `Deserilization of string ] ]) Deferred_result.t
 (** Start the server according to its configuration.  *)
 
 

--- a/src/pure/host.mli
+++ b/src/pure/host.mli
@@ -106,7 +106,7 @@ val shell_of_default_shell: t -> string -> string list
 
 val of_uri :
   Uri.t ->
-  (t, [> `Host_uri_parsing_error of bytes * bytes ]) Pvem.Result.t
+  (t, [> `Host_uri_parsing_error of string * string ]) Pvem.Result.t
 (** Get a [Host.t] from an URI (library {{:https://github.com/mirage/ocaml-uri}ocaml-uri});
     the “path” part of the URI is the playground.
 
@@ -130,7 +130,7 @@ val of_uri :
 *)
 
 val of_string: string ->
-  (t, [> `Host_uri_parsing_error of bytes * bytes ]) Pvem.Result.t
+  (t, [> `Host_uri_parsing_error of string * string ]) Pvem.Result.t
 (** Parse an {{:http://www.ietf.org/rfc/rfc3986.txt}RFC-3986}-compliant
     string into a host, see {!of_uri}. *)
 

--- a/src/pure/internal_pervasives.ml
+++ b/src/pure/internal_pervasives.ml
@@ -127,7 +127,7 @@ module Json = struct
     module Of_v0 (T: sig
         type t
         val to_yojson : t -> Yojson.Safe.json
-        val of_yojson : Yojson.Safe.json -> [ `Error of bytes | `Ok of t ]
+        val of_yojson : Yojson.Safe.json -> [ `Error of string | `Ok of t ]
       end) : WITH_VERSIONED_SERIALIZATION with type t := T.t = struct
       type 'a versioned = V0 of 'a [@@deriving yojson]
       let to_json t =

--- a/src/pure/protocol.ml
+++ b/src/pure/protocol.ml
@@ -81,7 +81,7 @@ module Process_sub_protocol = struct
 
   module Ssh_connection = struct
     type status = [
-      | `Alive of [ `Askpass_waiting_for_input of (float * bytes) list | `Idle ]
+      | `Alive of [ `Askpass_waiting_for_input of (float * string) list | `Idle ]
       | `Dead of string
       | `Configured
     ] [@@deriving yojson]

--- a/src/pure/protocol.mli
+++ b/src/pure/protocol.mli
@@ -69,7 +69,7 @@ module Process_sub_protocol : sig
   ]
   module Ssh_connection : sig
     type status = [
-      | `Alive of [ `Askpass_waiting_for_input of (float * bytes) list | `Idle ]
+      | `Alive of [ `Askpass_waiting_for_input of (float * string) list | `Idle ]
       | `Dead of string
       | `Configured
     ]


### PR DESCRIPTION
All the changes are `s/bytes/string/gc` except the function `read_fifo`
in `Process_holder.Ssh_connection` that now explicitly uses the `Bytes`
module.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/277)
<!-- Reviewable:end -->
