### PR TITLE
Make `ketrew start-server` report errors

### DIFF
--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -580,9 +580,10 @@ let do_start_the_server ?say_hi_to configuration =
         let content =
           let pid = Unix.getpid () in
           fmt "%s (PID: %d)\n%s%!"
-            Time.(now () |> to_filename) pid (Error.to_string e)
-        in
+            Time.(now () |> to_filename) pid (Error.to_string e) in
         Printf.eprintf "ERROR: Starting the server failed:\n%s\n%!" content;
+        just_before_listening ()
+        >>= fun () ->
         IO.write_file (path // server_error_filename) ~content
         >>= fun () ->
         fail e

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -841,7 +841,7 @@ let status ~configuration =
   end
 
 
-let start ~configuration  =
+let start ~just_before_listening ~configuration  =
   Log.(s "Set preemptive bounds: 10, 52" @ verbose);
   Lwt_preemptive.init 10 52 (fun str ->
       Log.(s " Lwt_preemptive error: " % s str @ error);
@@ -889,4 +889,6 @@ let start ~configuration  =
   >>= fun () ->
   Log.(s "Start-Server: Starting listening on connections" @ verbose);
   log_info Log.(s "Start-Server: Starting listening on connections");
+  just_before_listening ()
+  >>= fun () ->
   start_listening_on_connections ~server_state

--- a/src/lib/server.mli
+++ b/src/lib/server.mli
@@ -28,23 +28,31 @@ open Ketrew_pure.Internal_pervasives
 open Unix_io
 
 
-val start: configuration:Configuration.server ->
-  (unit,
-   [> `Database of Trakeva.Error.t
-   | `Dyn_plugin of
-        [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
-   | `Failure of string
-   | `IO of [> `Read_file_exn of string * exn ]
-   | `Missing_data of string
-   | `Server_status_error of string
-   | `Start_server_error of string
-   | `Database_unavailable of string
-   | `System of
-        [> `File_info of string
-        | `List_directory of string
-        | `Remove of string ] *
-        [> `Exn of exn ]
-   | `Target of [> `Deserilization of string ] ]) Deferred_result.t
+val start :
+  just_before_listening:(
+    unit ->
+    (unit,
+     [> `Database of Trakeva.Error.t
+     | `Database_unavailable of string
+     | `Dyn_plugin of
+          [> `Dynlink_error of Dynlink.error
+          | `Findlib of exn ]
+     | `Failure of string
+     | `IO of
+          [> `Read_file_exn of string * exn ]
+     | `Missing_data of string
+     | `Server_status_error of string
+     | `Start_server_error of string
+     | `System of
+          [> `File_info of string
+          | `List_directory of string
+          | `Remove of string ] *
+          [> `Exn of exn ]
+     | `Target of
+          [> `Deserilization of string ] ]
+     as 'propagated_error) Unix_io.t) ->
+  configuration:Configuration.server ->
+  (unit, 'propagated_error) Unix_io.t
 (** Start the server according to its configuration.  *)
 
 


### PR DESCRIPTION
This is a fix for #252, the `System.sleep 2.` could be improved upon in
the future; it may also require tweaking the actual value.

With a server configured on a root-only port:

     $ kddaemon start
    [ketrew] Started the daemon, now waiting for the server
    status.
    [ketrew] The server seems to have failed to start
    (connection refused).
    [ketrew]
        Here is the latest start-error:
    2015-11-24-22h54m18s032ms-UTC (PID: 52689)
    Error starting the server: Unix.Unix_error(Unix.EACCES, "bind", "")

the “old” behavior is still available with the `--no-status` option:

     $ kddaemon start --no-status
    <silently returns immediately>

there is also a `Printf.eprintf` to be sure the error is seen when not
daemonizing:

     $ kdserver start
    ERROR: Starting the server failed:
    2015-11-24-22h54m38s015ms-UTC (PID: 52778)
    Error starting the server: Unix.Unix_error(Unix.EACCES, "bind", "")

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/290)
<!-- Reviewable:end -->
