### PR TITLE
Disable the `log` query in  YARN backend

### DIFF
--- a/src/lib/yarn.ml
+++ b/src/lib/yarn.ml
@@ -152,7 +152,10 @@ let additional_queries run_param =
        Log.(s "Call the YARN API and format the result"));
     ]
     @ (Daemonize.additional_queries rp.daemonized_script
-       |> List.filter ~f:(fun (n, _) -> n <> "ketrew-markup/status"))
+       |> List.filter ~f:(fun (n, _) ->
+           n <> "ketrew-markup/status"
+           && n <> "log"
+         ))
 
 (*
 Dirty way of finding the application ID: we parse the output to find the logging


### PR DESCRIPTION
The `log` (the one of the daemonized script) was useless and confusing
users because of its name is too close to `logs` (the `yarn logs
<appid>` one).

This fixes #297.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/310)
<!-- Reviewable:end -->
