### PR TITLE
Fix use of `React.S.map` without `--no-inline`

### DIFF
--- a/OMakeroot
+++ b/OMakeroot
@@ -40,8 +40,7 @@ if $(test $(getenv JSOO_DEBUG_MODE, "") = true)
     JSOO_FLAGS=--pretty --no-inline --debug-info
     export
 else
-    # Seems necessary
-    JSOO_FLAGS= --no-inline
+    JSOO_FLAGS=
     export
 
 OCAMLFLAGS = -bin-annot -thread -short-paths -g -strict-formats -strict-sequence -w +9 -safe-string

--- a/src/client-joo/single_client.ml
+++ b/src/client-joo/single_client.ml
@@ -993,7 +993,7 @@ module Html = struct
     let current_tab = client.current_tab in
     let tabs =
       Reactive.Source.signal client.tabs
-      |> Reactive.Signal.map ~f:(fun tabs ->
+      |> React.S.map ~eq:(fun _ _ -> false) (fun tabs ->
           List.map tabs ~f:begin function
           | `Target_table ->
             Bootstrap.tab_item


### PR DESCRIPTION
The option for `js_of_ocaml` was there because of a misunderstood issue;
adding the `~eq` parameter of `React.S.map` fixes that inlining was
revealing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/313)
<!-- Reviewable:end -->
