### PR TITLE
Upgrade to `reactiveData` 0.2 API changes

### DIFF
--- a/opam
+++ b/opam
@@ -26,7 +26,7 @@ depends: [
   "ppx_deriving" "ppx_deriving_yojson" {>= "2.3"}
   "cohttp" {>= "0.17.0" } "lwt"
   "conduit"
-  "js_of_ocaml" {>= "2.6" } "tyxml" "reactiveData" {= "0.1"}
+  "js_of_ocaml" {>= "2.6" } "tyxml" "reactiveData" {>= "0.2"}
   ]
 depopts: [
   "sqlite3" "postgresql"

--- a/src/client-joo/reactive_html5.mli
+++ b/src/client-joo/reactive_html5.mli
@@ -9,8 +9,7 @@ module H5: sig
   open Tyxml_js
   include Html5_sigs.Make(Xml)(Svg).T
   module Reactive_node:
-    (* module type of Tyxml_js.R.Html5 *)
-    Html5_sigs.MakeWrapped(Xml_wrap)(Xml)(Svg).T
+    Html5_sigs.Make(Tyxml_js.R.Xml)(Tyxml_js.R.Svg).T
     with type +'a elt = 'a elt
      and type +'a attrib = 'a attrib
 

--- a/src/pure/reactive.ml
+++ b/src/pure/reactive.ml
@@ -16,13 +16,13 @@ module Signal = struct
 
   let singleton t =
     let open ReactiveData.RList in
-    make_from
+    from_event
       [React.S.value t]
       (React.E.map (fun e -> Set [e]) (React.S.changes t))
 
   let list t =
     let open ReactiveData.RList in
-    make_from
+    from_event
       (React.S.value t)
       (React.E.map (fun e -> Set e) (React.S.changes t))
 


### PR DESCRIPTION
The change implies other dependency constraint changes, as `opam` said:

-  ↗  upgrade js_of_ocaml  2.6 to 2.7
-  ↗  upgrade reactiveData 0.1 to 0.2
-  ↗  upgrade tyxml        3.5.0 to 3.6.0

This fixes #329.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/338)
<!-- Reviewable:end -->
