### PR TITLE
Add a thorough `Lwt.async_exception_hook`

### DIFF
--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -876,6 +876,20 @@ let start ~just_before_listening ~configuration  =
   Lwt_preemptive.init 10 52 (fun str ->
       Log.(s " Lwt_preemptive error: " % s str @ error);
     );
+  Lwt.async_exception_hook := begin fun e ->
+    Log.(s " Lwt async error: " % exn e @ error);
+    let backtrace = Printexc.get_backtrace () in
+    Printf.eprintf "Lwt-async-exn: %s\nBacktrace:\n%s\n%!"
+      (Printexc.to_string e) backtrace;
+    Logger.(
+      log
+        Display_markup.(
+          description_list [
+            "Location", text "Lwt.async_exception_hook";
+            "Exception", text (Printexc.to_string e);
+            "Backtrace", code_block backtrace;
+          ]));
+  end;
   begin
     status ~configuration
     >>= function


### PR DESCRIPTION
It seems that some configurations of `Conduit` 0.10.0 let exceptions kill
the program; we don't.

This may leave a problem with leaked file-descriptors.

The log entry looks like (pretty-printed):

```
========================================================================[2]
[2016-02-12-15h21m33s590ms-UTC]
* Location: Lwt.async_exception_hook
* Exception: Failure("Booooooh")
* Backtrace: Raised at file "bytes.ml", line 231, characters 22-31
Called from file "string.ml", line 104, characters 2-20
```

when adding a:

```ocaml
  Lwt.(
    async @@ fun () ->
    Lwt_unix.sleep 1.
    >>= fun () ->
    Printf.eprintf "Slept and failing \n%!";
    failwith "Booooooh"
  );
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/357)
<!-- Reviewable:end -->
