### PR TITLE
Improve scalability

### DIFF
--- a/src/client-joo/target_table.ml
+++ b/src/client-joo/target_table.ml
@@ -300,8 +300,7 @@ module Filter = struct
     | Some t ->
       (* Those 5 seconds actually generate traffic, but for know, who cares … *)
       { query with
-        Protocol.Up_message.time_constraint =
-          `Status_changed_since (t -. 1.)}
+        Protocol.Up_message.time_constraint = `Status_changed_since t}
     | None -> query
 
   let to_lisp { ast } =

--- a/src/lib/client.ml
+++ b/src/lib/client.ml
@@ -247,10 +247,10 @@ let add_targets t tlist =
   | `Http_client c ->
     Http_client.add_targets c tlist
 
-let all_targets = function
+let all_visible_targets = function
 | `Standalone s ->
   let open Standalone in
-  Engine.all_targets s.engine
+  Engine.all_visible_targets s.engine
 | `Http_client c ->
   Http_client.get_current_targets c
 

--- a/src/lib/client.ml
+++ b/src/lib/client.ml
@@ -172,7 +172,7 @@ module Http_client = struct
       >>= filter_down_message
         ~loc:`Targets
         ~f:(function
-          | `List_of_target_ids tl -> Some (`Done tl)
+          | `List_of_target_ids (tl, (_ : Time.t)) -> Some (`Done tl)
           | `Deferred_list_of_target_ids (id, total) -> (* id × total-length *)
             Log.(s "Deferred_list_of_target_ids: " % s id % sf "(total: %d)" total
                  @ verbose);

--- a/src/lib/client.mli
+++ b/src/lib/client.mli
@@ -82,7 +82,7 @@ val get_local_engine: t -> Engine.t option
 (** Get the handle to the engine (returns [None] if the client is
     an HTTP one). *)
 
-val all_targets: t -> 
+val all_visible_targets: t -> 
   (Ketrew_pure.Target.t list,
    [> `Client of Error.t
    | `Database of Trakeva.Error.t

--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -39,7 +39,7 @@ module Return_code = struct
 end
 
 let get_status ~client =
-  Client.all_targets client
+  Client.all_visible_targets client
   >>= fun targets ->
   let in_progress =
     List.fold targets ~init:0 ~f:(fun prev t ->

--- a/src/lib/configuration.ml
+++ b/src/lib/configuration.ml
@@ -69,7 +69,6 @@ type server = {
   server_engine: engine;
   server_ui: ui;
   max_blocking_time: (float [@default 300.]);
-  block_step_time: (float [@default 3.]);
   read_only_mode: (bool [@default false]);
   ssh_connections: (ssh_connection list [@default []]);
   ssh_processes_ui: (bool [@default default_ssh_processes_ui]);
@@ -183,7 +182,6 @@ let log t =
           item "Log-path" (OCaml.option quote srv.log_path);
           item "Return-error-messages" (OCaml.bool srv.return_error_messages);
           item "Max-blocking-time" (OCaml.float srv.max_blocking_time);
-          item "Block-step-time" (OCaml.float srv.block_step_time);
           item "Listen"
             begin match srv.listen_to with
             | `Tls (cert, key, port) ->
@@ -262,7 +260,6 @@ let server
     ?(authorized_tokens=[]) ?(return_error_messages=false)
     ?command_pipe ?(daemon=false) ?log_path
     ?(max_blocking_time = 300.)
-    ?(block_step_time = 3.)
     ?(read_only_mode = false)
     ?(ssh_connections = [])
     ?(ssh_processes_ui = default_ssh_processes_ui)
@@ -271,7 +268,7 @@ let server
   let server_ui = Option.value ui ~default:default_ui in
   (`Server {server_engine; authorized_tokens; listen_to; server_ui;
             return_error_messages; command_pipe; daemon; log_path;
-            max_blocking_time; block_step_time; read_only_mode;
+            max_blocking_time; read_only_mode;
             ssh_connections; ssh_processes_ui})
 
 
@@ -299,7 +296,6 @@ let server_engine s = s.server_engine
 let connection c = c.connection
 let token c = c.token
 let max_blocking_time s = s.max_blocking_time
-let block_step_time s = s.block_step_time
 let read_only_mode s = s.read_only_mode
 
 let standalone_of_server s =

--- a/src/lib/configuration.mli
+++ b/src/lib/configuration.mli
@@ -162,7 +162,6 @@ val server:
   ?daemon: bool ->
   ?log_path: string ->
   ?max_blocking_time: float ->
-  ?block_step_time: float ->
   ?read_only_mode: bool ->
   ?ssh_connections:ssh_connection list ->
   ?ssh_processes_ui:bool ->
@@ -191,9 +190,6 @@ val server:
     - [max_blocking_time]: 
       upper bound on the request for blocking in the protocol (seconds,
       default [300.]).
-    - [block_step_time]: 
-      granularity of the checking for blocking conditions (this will
-      hopefully disapear soon) (seconds, default [3.]).
     - [read_only_mode]:
       run the server in read-only mode (default [false]).
     - [ssh_connections]: preconfigure named SSH connections (default [[]]).
@@ -327,7 +323,6 @@ val targets_per_page: t -> int
 val targets_to_prefetch: t -> int
 
 val max_blocking_time: server -> float
-val block_step_time:   server -> float
 val read_only_mode:    server -> bool
 
 val use_cbreak: unit -> bool

--- a/src/lib/configuration.mli
+++ b/src/lib/configuration.mli
@@ -92,6 +92,7 @@ val engine:
   ?host_timeout_upper_bound: float ->
   ?maximum_successive_attempts: int ->
   ?concurrent_automaton_steps: int ->
+  ?archival_age_threshold : [ `Days of float ] ->
   unit -> engine
 (** Build an [engine] configuration:
 
@@ -111,6 +112,8 @@ val engine:
     - [concurrent_automaton_steps]: maximum number of steps in the
       state machine that engine will try to run concurrently (default
       is [4]).
+    - [archival_age_threshold]: amount of for which a finished workflow-node is
+      visible in the user-interface (default: 10 days).
 *)
 
 type authorized_tokens 
@@ -273,6 +276,9 @@ val concurrent_automaton_steps: engine -> int
 
 val host_timeout_upper_bound : engine -> float option
 (** Get the upper bound for the timeout of SSH calls, if any. *)
+
+val archival_age_threshold: engine -> [ `Days of float ]
+(** Get the maximal ago of easily visible workflow-nodes *)
 
 val plugins: t ->  plugin list
 (** Get the configured list of plugins. *)

--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -69,7 +69,7 @@ let with_engine ~configuration f =
 
 let configuration t = t.configuration
 
-let next_change ?limit t = Persistent_data.next_change ?limit t.data
+let next_changes t = Persistent_data.next_changes t.data
 
 module Run_automaton = struct
 
@@ -411,10 +411,7 @@ let get_list_of_target_ids t query =
         | `Status_changed_since time ->
           let (`Time t, _, _) = Target.(state target |> State.summary) in
           begin match time <= t with
-          | true ->
-            (* Printf.eprintf "Status_changed_since: %s Vs %s\n%!" *)
-            (*   (Time.to_string_hum time) (Time.to_string_hum t); *)
-            wins ()
+          | true -> wins ()
           | false -> None
           end
         end

--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -35,7 +35,9 @@ include Make_module_error_and_info(struct
   end)
 
 let create configuration =
-  Persistent_data.create (Configuration.database_parameters configuration)
+  Persistent_data.create
+    (Configuration.database_parameters configuration)
+    (Configuration.archival_age_threshold configuration)
   >>= fun data ->
   return {data; configuration; host_io = Host_io.create ()}
 

--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -69,6 +69,7 @@ let with_engine ~configuration f =
 
 let configuration t = t.configuration
 
+let next_change ?limit t = Persistent_data.next_change ?limit t.data
 
 module Run_automaton = struct
 
@@ -410,7 +411,10 @@ let get_list_of_target_ids t query =
         | `Status_changed_since time ->
           let (`Time t, _, _) = Target.(state target |> State.summary) in
           begin match time <= t with
-          | true -> wins ()
+          | true ->
+            Printf.eprintf "Status_changed_since: %s Vs %s\n%!"
+              (Time.to_string_hum time) (Time.to_string_hum t);
+            wins ()
           | false -> None
           end
         end

--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -383,7 +383,7 @@ let get_status t id =
 
 let get_list_of_target_ids t query =
   let start_time = Time.now () in
-  Persistent_data.all_targets t.data
+  Persistent_data.all_visible_targets t.data
   >>= fun targets ->
   let all_targets_time = Time.now () in
   let list_of_ids =
@@ -493,8 +493,8 @@ let restart_target engine target_id =
     ~old_id:target_id ~new_id:id ~name:(Target.name this_new_target);
   return id
 
-let all_targets t =
-  Persistent_data.all_targets t.data
+let all_visible_targets t =
+  Persistent_data.all_visible_targets t.data
 let get_target t id =
   Persistent_data.get_target t.data id
 let add_targets t l =

--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -412,8 +412,8 @@ let get_list_of_target_ids t query =
           let (`Time t, _, _) = Target.(state target |> State.summary) in
           begin match time <= t with
           | true ->
-            Printf.eprintf "Status_changed_since: %s Vs %s\n%!"
-              (Time.to_string_hum time) (Time.to_string_hum t);
+            (* Printf.eprintf "Status_changed_since: %s Vs %s\n%!" *)
+            (*   (Time.to_string_hum time) (Time.to_string_hum t); *)
             wins ()
           | false -> None
           end

--- a/src/lib/engine.mli
+++ b/src/lib/engine.mli
@@ -107,6 +107,8 @@ val get_list_of_target_ids: t ->
 - [`Not_finished_before _] for the targets that were not finished at a given date.
 *)
 
+val next_change: ?limit:float -> t -> (Persistent_data.Change.t list, 'a) Deferred_result.t
+
 module Run_automaton : sig
   val step :
     t ->

--- a/src/lib/engine.mli
+++ b/src/lib/engine.mli
@@ -81,7 +81,7 @@ val get_target: t -> Unique_id.t ->
     Deferred_result.t
 (** Get a target from its id. *)
 
-val all_targets :
+val all_visible_targets :
   t ->
   (Ketrew_pure.Target.t list,
    [> `Database of Trakeva.Error.t

--- a/src/lib/engine.mli
+++ b/src/lib/engine.mli
@@ -107,7 +107,9 @@ val get_list_of_target_ids: t ->
 - [`Not_finished_before _] for the targets that were not finished at a given date.
 *)
 
-val next_change: ?limit:float -> t -> (Persistent_data.Change.t list, 'a) Deferred_result.t
+val next_changes: t -> (Persistent_data.Change.t list, 'a) Deferred_result.t
+(** Block until the next batch of changes happening at the persistence-level,
+    this stream is itself rate-limited. *)
 
 module Run_automaton : sig
   val step :

--- a/src/lib/interaction.ml
+++ b/src/lib/interaction.ml
@@ -215,7 +215,7 @@ let sort_target_list =
   List.sort ~cmp:(fun ta tb -> compare (Ketrew_pure.Target.id tb) (Ketrew_pure.Target.id ta))
 
 let build_sublist_of_targets ~client ~list_name ~all_log ~go_verb ~filter =
-  Client.all_targets client
+  Client.all_visible_targets client
   >>| List.filter ~f:(fun target -> filter target)
   >>| sort_target_list
   >>= fun all_targets ->

--- a/src/lib/persistent_data.ml
+++ b/src/lib/persistent_data.ml
@@ -563,7 +563,7 @@ let get_target t id =
   get_following_pointers ~key:id ~count:0
 
 
-let all_targets t =
+let all_visible_targets t =
   let start_date = Time.now () in
   (*
   With_database.iter_all_target_ids t.db

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -94,6 +94,12 @@ val update_target :
    | `Database_unavailable of string ])
     Deferred_result.t
 
+module Change : sig
+  type t = [ `Started | `New_nodes of string list | `Nodes_changed of string list ]
+    [@@deriving show]
+end
+val next_change: ?limit:float -> t -> (Change.t list, 'a) Deferred_result.t
+
 module Killing_targets: sig
 
   val proceed_to_mass_killing :

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -47,7 +47,7 @@ val get_target:
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 
-val all_targets :
+val all_visible_targets :
   t ->
   (Ketrew_pure.Target.t list,
    [>  `Database of Trakeva.Error.t

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -26,6 +26,7 @@ type t
 
 val create :
   database_parameters:string ->
+  archival_age_threshold:[ `Days of float ] ->
   (t,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of string

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -98,7 +98,7 @@ module Change : sig
   type t = [ `Started | `New_nodes of string list | `Nodes_changed of string list ]
     [@@deriving show]
 end
-val next_change: ?limit:float -> t -> (Change.t list, 'a) Deferred_result.t
+val next_changes: t -> (Change.t list, 'a) Deferred_result.t
 
 module Killing_targets: sig
 

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -216,9 +216,13 @@ let block_if_empty_at_most ~server_state
                 (String.concat ~sep:"," @@ List.map ~f:Persistent_data.Change.show change);
               loop ()
             end;
-            begin System.sleep 10. >>< fun _ ->
-              Printf.eprintf "Sleep to maximum\n%!";
-              loop ()
+            begin System.sleep 10.
+              >>< function
+              | `Ok () ->
+                Printf.eprintf "Sleep to maximum\n%!"; loop ()
+              | `Error (`System (_, `Exn exn)) ->
+                Printf.eprintf "Didn't sleep to maximum : %s\n%!" (Printexc.to_string exn);
+                loop ()
             end;
           ]
         )

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -181,8 +181,6 @@ let block_if_empty_at_most
     get_values () >>= send
   | Some (`Block_if_empty_at_most req_block_time) ->
     let start_time = Time.now () in
-    (* let sleep_time = *)
-    (*   Configuration.block_step_time server_state.server_configuration in *)
     let block_time =
       let max_block_time =
         Configuration.max_blocking_time server_state.server_configuration in

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -221,7 +221,7 @@ module Engine_instructions = struct
 
   let from_ids ~server_state = function
     | [] ->
-      Engine.all_targets server_state.state
+      Engine.all_visible_targets server_state.state
       >>| List.map ~f:(fun trt -> (Target.id trt, trt))
     | more ->
       Deferred_list.while_sequential more ~f:(fun id ->

--- a/src/pure/internal_pervasives.ml
+++ b/src/pure/internal_pervasives.ml
@@ -159,6 +159,8 @@ module Time = struct
 
   let now () : t = Unix.gettimeofday ()
 
+  let days n = float n *. 60. *. 60. *. 24.
+
   let to_filename f =
     let open Unix in
     let tm = gmtime f in

--- a/src/pure/internal_pervasives.ml
+++ b/src/pure/internal_pervasives.ml
@@ -173,6 +173,18 @@ module Time = struct
       (tm.tm_sec)
       ((f -. (floor f)) *. 1000. |> int_of_float)
 
+  let to_string_hum f =
+    let open Unix in
+    let tm = localtime f in
+    fmt "%04d-%02d-%02d-%02dh%02dm%02ds%03dms"
+      (tm.tm_year + 1900)
+      (tm.tm_mon + 1)
+      (tm.tm_mday)
+      (tm.tm_hour)
+      (tm.tm_min)
+      (tm.tm_sec)
+      ((f -. (floor f)) *. 1000. |> int_of_float)
+
   let log f = Log.s (to_filename f)
 
   let show f = to_filename f

--- a/src/pure/internal_pervasives.ml
+++ b/src/pure/internal_pervasives.ml
@@ -159,7 +159,7 @@ module Time = struct
 
   let now () : t = Unix.gettimeofday ()
 
-  let days n = float n *. 60. *. 60. *. 24.
+  let day = 60. *. 60. *. 24.
 
   let to_filename f =
     let open Unix in

--- a/src/pure/protocol.ml
+++ b/src/pure/protocol.ml
@@ -127,7 +127,7 @@ module Down_message = struct
       | `List_of_targets of Target.t list
       | `List_of_target_summaries of (string (* ID *) * Target.Summary.t) list
       | `List_of_target_flat_states of (string (* ID *) * Target.State.Flat.t) list
-      | `List_of_target_ids of string list
+      | `List_of_target_ids of string list * float (* IDs × server-time *)
       | `Deferred_list_of_target_ids of string * int (* id × total-length *)
       | `List_of_query_descriptions of (string * string) list
       | `Query_result of string

--- a/src/pure/protocol.ml
+++ b/src/pure/protocol.ml
@@ -151,9 +151,9 @@ module Up_message = struct
       | `Not_finished_before of float
       | `Created_after of float
       | `Status_changed_since of float
-    ] [@@deriving yojson]
+    ] [@@deriving yojson,show]
     type string_predicate = [`Equals of string | `Matches of string]
-        [@@deriving yojson]
+        [@@deriving yojson,show]
     type filter = [
       | `True
       | `False
@@ -170,14 +170,14 @@ module Up_message = struct
       | `Has_tag of string_predicate
       | `Name of string_predicate
       | `Id of string_predicate
-    ] [@@deriving yojson]
+    ] [@@deriving yojson,show]
     type target_query = {
       time_constraint : time_constraint;
       filter : filter;
-    } [@@deriving yojson]
+    } [@@deriving yojson,show]
     type query_option = [
       | `Block_if_empty_at_most of float
-    ] [@@deriving yojson]
+    ] [@@deriving yojson,show]
     type t = [
       | `Get_targets of string list (* List of Ids, empty means “all” *)
       | `Get_target_summaries of string list (* List of Ids, empty means “all” *)

--- a/src/pure/protocol.mli
+++ b/src/pure/protocol.mli
@@ -111,10 +111,10 @@ module Down_message : sig
   type t = [
     | `List_of_targets of Target.t list
     | `List_of_target_summaries of (string (* ID *) * Target.Summary.t) list
-      (* We provide the IDs back because the target could be a
+    (* We provide the IDs back because the target could be a
          pointer, Summary.id can be different. *)
     | `List_of_target_flat_states of (string (* ID *) * Target.State.Flat.t) list
-    | `List_of_target_ids of string list
+    | `List_of_target_ids of string list * float (* IDs × server-time *)
     | `Deferred_list_of_target_ids of string * int (* id × total-length *)
     | `List_of_query_descriptions of (string * string) list
     | `Query_result of string

--- a/src/pure/protocol.mli
+++ b/src/pure/protocol.mli
@@ -157,7 +157,7 @@ module Up_message : sig
   type target_query = {
     time_constraint : time_constraint;
     filter : filter;
-  }
+  } [@@deriving show]
   type query_option = [
     | `Block_if_empty_at_most of float
   ]

--- a/src/pure/target.mli
+++ b/src/pure/target.mli
@@ -134,7 +134,7 @@ module State : sig
     | `In_progress
     | `Successful
     | `Failed
-  ] [@@deriving yojson]
+  ] [@@deriving yojson,show]
   val simplify: t -> simple
 
   val name: t -> string


### PR DESCRIPTION

In few words:

- the UIs now see a "young" subset of the universe (default: 10 days)
- the busy wait in `block_if_empty_at_most` is gone; there is now a proper,
  wait that gets signaled by the `Persistent_data` with a rate-limited stream
  of events.
- The UI now gets the server-time more often hence can request more precise
  queries (“what happened since `t`?”).
- The configuration option `block_step_time` is now obsolete and removed; which
  makes the configuration format not backwards compatible.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/388)
<!-- Reviewable:end -->
