### PR TITLE
Improve “status fetching” from the WebUI

### DIFF
--- a/src/client-joo/local_cache.ml
+++ b/src/client-joo/local_cache.ml
@@ -107,12 +107,12 @@ module Target_cache  = struct
     (* Hashtbl.replace targets id signal; *)
     ()
 
-  let update_flat_state t ~id more_state =
+  let update_flat_state t ~server_time ~id more_state =
     let source = _get_target_flat_status t ~id in
     let current = Reactive.(Source.signal source |> Signal.value) in
-    Reactive.Source.set source
-      {retrieved = Some (Time.now ());
-       value = Target.State.Flat.merge current.value more_state};
+    let value = Target.State.Flat.merge current.value more_state in
+    let retrieved = Some server_time in
+    Reactive.Source.set source {retrieved; value};
     ()
 
   let update_target_query_descriptions t ~id v =

--- a/src/client-joo/local_cache.mli
+++ b/src/client-joo/local_cache.mli
@@ -49,7 +49,8 @@ module Target_cache: sig
     t -> id:Ketrew_pure.Target.id -> target_knowledge -> unit
 
   val update_flat_state :
-    t -> id:Ketrew_pure.Target.id -> Ketrew_pure.Target.State.Flat.t -> unit
+    t -> server_time: Time.t ->
+    id:Ketrew_pure.Target.id -> Ketrew_pure.Target.State.Flat.t -> unit
 
   val update_target_query_descriptions :
     t -> id:Ketrew_pure.Target.id -> query_description -> unit

--- a/src/client-joo/single_client.ml
+++ b/src/client-joo/single_client.ml
@@ -577,7 +577,7 @@ let start_getting_flat_statuses t =
               | Some pr, None -> None
               | Some pr, Some nw -> Some (min pr nw))
           |> function
-          | Some t -> `Since (t -. 1.)
+          | Some t -> `Since t
           | None -> `All in
         Protocol_client.call t.protocol_client
           ~timeout:(t.block_time_request
@@ -587,11 +587,12 @@ let start_getting_flat_statuses t =
                                        t.block_time_request]))
         >>= fun msg_down ->
         begin match msg_down with
-        | `List_of_target_flat_states l ->
+        | `List_of_target_flat_states (l, server_time) ->
           (* Log.(s "fill_cache_loop got " % i (List.length l) % s " flat-states" *)
           (*      @ verbose); *)
           List.iter l ~f:begin fun (id, value) ->
             Target_cache.update_flat_state t.target_cache ~id value
+              ~server_time
           end;
           sleep sleep_time
           >>= fun () ->

--- a/src/pure/protocol.ml
+++ b/src/pure/protocol.ml
@@ -126,7 +126,8 @@ module Down_message = struct
     type t = [
       | `List_of_targets of Target.t list
       | `List_of_target_summaries of (string (* ID *) * Target.Summary.t) list
-      | `List_of_target_flat_states of (string (* ID *) * Target.State.Flat.t) list
+      | `List_of_target_flat_states of
+          (string (* ID *) * Target.State.Flat.t) list * float (* server-time *)
       | `List_of_target_ids of string list * float (* IDs × server-time *)
       | `Deferred_list_of_target_ids of string * int (* id × total-length *)
       | `List_of_query_descriptions of (string * string) list

--- a/src/pure/protocol.mli
+++ b/src/pure/protocol.mli
@@ -113,7 +113,8 @@ module Down_message : sig
     | `List_of_target_summaries of (string (* ID *) * Target.Summary.t) list
     (* We provide the IDs back because the target could be a
          pointer, Summary.id can be different. *)
-    | `List_of_target_flat_states of (string (* ID *) * Target.State.Flat.t) list
+    | `List_of_target_flat_states of
+        (string (* ID *) * Target.State.Flat.t) list * float (* server-time *)
     | `List_of_target_ids of string list * float (* IDs × server-time *)
     | `Deferred_list_of_target_ids of string * int (* id × total-length *)
     | `List_of_query_descriptions of (string * string) list


### PR DESCRIPTION
This makes the “time-constraints” more precise; the server sends it's current
time with the statuses so that the client can ask only for the newer ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/389)
<!-- Reviewable:end -->
