### PR TITLE
Fix semantics of `is-dependency-dead`

### DIFF
--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -442,7 +442,7 @@ let get_list_of_target_ids t query =
               || Is.ran_successfully state
             | `Killable -> Is.killable state
             | `Dead_because_of_dependencies ->
-              Is.finished_because_dependencies_died state
+              Is.dependency_dead state
             | `Activated_by_user ->
               Is.activated_by_user state
             end

--- a/src/pure/target.ml
+++ b/src/pure/target.ml
@@ -721,9 +721,10 @@ type state = [
     | #killable_state -> true
     | _ -> false
 
-    let finished_because_dependencies_died =
+    let dependency_dead =
       function
       | `Finished {previous_state = (`Dependencies_failed _); _ } -> true
+      | `Dependencies_failed _ -> true
       | other -> false
 
     let activated_by_user s =

--- a/src/pure/target.mli
+++ b/src/pure/target.mli
@@ -173,7 +173,7 @@ module State : sig
     val finished : t -> bool
     val passive : t -> bool
     val killable: t -> bool
-    val finished_because_dependencies_died: t -> bool
+    val dependency_dead: t -> bool
     val activated_by_user: t -> bool
   end
 


### PR DESCRIPTION
This fixes #393. The name of the function was also changed to avoid confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/394)
<!-- Reviewable:end -->
