### PR TITLE
Add notification when root-nodes are collapsed

### DIFF
--- a/src/lib/logging.ml
+++ b/src/lib/logging.ml
@@ -157,6 +157,7 @@ module User_level_events = struct
       | `Workflow_node_killed of string
       | `Workflow_node_restarted of string * string * string
       | `Server_shut_down
+      | `Root_workflow_equivalent_to of string * string * (string * string) list
     ]
     } [@@deriving yojson]
 
@@ -176,6 +177,11 @@ module User_level_events = struct
       fmt "Workflow `%s` resubmitted as `%s` (%s)"
         old_id new_id name
     | `Server_shut_down -> fmt "Server (about to) shut down"
+    | `Root_workflow_equivalent_to (name, id, name_ids) ->
+      fmt "Root workflow-node: %s (%s) is equivalent to %s"
+        name id
+        (List.map name_ids ~f:(fun (name, id) -> fmt "%s (%s)" name id)
+         |> String.concat ~sep:", ")
 
   type t = {
     ring: item Ring.t;
@@ -207,6 +213,9 @@ module User_level_events = struct
   let workflow_node_restarted ~old_id ~new_id ~name =
     add_item (`Workflow_node_restarted (old_id, new_id, name))
   let server_shut_down () = add_item `Server_shut_down
+
+  let root_workflow_equivalent_to ~name ~id equivalences =
+    add_item (`Root_workflow_equivalent_to (name, id, equivalences))
 
   let get_notifications_or_block ~query =
     begin match query with

--- a/src/lib/persistent_data.ml
+++ b/src/lib/persistent_data.ml
@@ -441,6 +441,15 @@ module With_database = struct
             | [] ->
               (Target.Stored_target.of_target target :: to_store_targets)
             | at_least_one :: _ ->
+              (
+                if Target.State.Is.activated_by_user (Target.state target)
+                then
+                  Logging.User_level_events.root_workflow_equivalent_to
+                    ~name:(Target.name target)
+                    ~id:(Target.id target)
+                    (List.map equivalences ~f:(fun st ->
+                         (Target.name st, Target.id st)))
+              );
               (Target.Stored_target.make_pointer
                  ~from:target ~pointing_to:at_least_one :: to_store_targets)
           end


### PR DESCRIPTION
It can be confusing when submiting workflows where the root node has a
condition and get collapsed because of their equivalence.

Tested with

```ocaml
let () =
  let open Ketrew.EDSL in
  workflow_node (single_file "/tmp/bouh")
    ~name:"Test Workflow"
    ~make:(
      daemonize Program.( sh "sleep 300" )
        ~using:`Python_daemon
    )
  |>
  Ketrew.Client.submit_workflow
    ~override_configuration:Ketrew.Configuration.(
        client "https://127.0.0.1:8443" (*  `kddaemon` in test environment *)
          ~token:"nekot"
        |> create
      )
```

<img width="1247" alt="screenshot 2016-03-25 13 33 57" src="https://cloud.githubusercontent.com/assets/617111/14050026/67d2f886-f28f-11e5-95a6-8736360ad626.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/410)
<!-- Reviewable:end -->
