### PR TITLE
Make collapsing more progressive

### DIFF
--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -117,7 +117,7 @@ module Run_automaton = struct
     end
 
   let _check_and_activate_dependencies t ~dependency_of ~ids =
-    Deferred_list.for_concurrent ids ~f:(fun dep ->
+    Deferred_list.for_sequential ids ~f:(fun dep ->
         Persistent_data.get_target t.data dep >>< function
         | `Ok dependency ->
           begin match Target.state dependency |> Target.State.simplify with

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -63,10 +63,15 @@ val activate_target :
   reason:[ `Dependency of Target.id | `User ] ->
   (unit,
    [> `Database of
-        [> `Act of Trakeva.Action.t | `Load of string ] * string
-   | `Database_unavailable of string ])
+        [> `Act of Trakeva.Action.t
+        | `Get of Trakeva.Key_in_collection.t
+        | `Get_all of string
+        | `Load of string ] *
+        string
+   | `Database_unavailable of string
+   | `Missing_data of string
+   | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
-
 
 val fold_active_targets :
   t ->

--- a/src/pure/internal_pervasives.ml
+++ b/src/pure/internal_pervasives.ml
@@ -265,6 +265,8 @@ module Display_markup = struct
   let option o ~f =
     Option.value_map ~f ~default:(Text "None") o
 
+  let date_now () = date (Time.now ())
+
   let rec log =
     function
     | Date f -> Time.log f


### PR DESCRIPTION
With this patch, incomming workflows are merged only against themselves and active nodes;
then, when a node is activated it is, again, checked against all the other
active ones.

So far, it seems to work:

- The WebUI can get a bit confused, depending on when they download things to
  browsers can get a different view of the world (things become pointers after
  they are cache). It still works, but the duplicates can be confusing.
- Requires less parallelism: I had to set concurrent-steps to 1 and force
  activation of dependencies to be sequential.

I've been testing with variants of this:

```ocaml
let () = Sys.command "rm -fr /tmp/ktt-*" |> ignore

let call = ref 0

let () =
  let open Ketrew.EDSL in
  let open Printf in
  let rec dep ?(r = true) path =
    workflow_node (single_file path) ~name:path
      ~edges:(
        if r then [dep ~r:false "/tmp/ktt-osa" |> on_success_activate] else []
      )
      ~make:(
        daemonize Program.(shf "sleep 60 > %s" path)
          ~using:`Python_daemon
      )
  in
  workflow_node without_product
    ~name:(incr call; Printf.sprintf "test %d" !call)
    ~edges:[
      depends_on @@ dep @@ sprintf "/tmp/ktt-1-%d" !call;
      depends_on @@ dep @@ sprintf "/tmp/ktt-1-%d" !call;
      depends_on @@ dep @@ sprintf "/tmp/ktt-2-%d" !call;
    ]
  |>
  Ketrew.Client.submit_workflow
    ~override_configuration:Ketrew.Configuration.(
        client "http://127.0.0.1:8080"
          ~token:"nekot"
        |> create
      )

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/412)
<!-- Reviewable:end -->
