### PR TITLE
Better error handling

### DIFF
--- a/src/lib/client.mli
+++ b/src/lib/client.mli
@@ -61,7 +61,7 @@ val as_client:
       | `Dyn_plugin of
            [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
       | `Failure of string
-      | `Missing_data of string
+      | `Fetching_node of Persistent_data.Error.fetching_node
       | `Target of [> `Deserilization of string ]
       | `Wrong_configuration of
            [> `Found of string ] * [> `Exn of exn ] ]
@@ -89,7 +89,7 @@ val all_visible_targets: t ->
    | `Database_unavailable of string
    | `IO of
         [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
-   | `Missing_data of Ketrew_pure.Target.id
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `System of [> `File_info of string ] * [> `Exn of exn ]
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
@@ -101,7 +101,7 @@ val get_list_of_target_ids : t ->
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 (** Get a list of target IDs given the [query]. *)
@@ -112,9 +112,9 @@ val get_target: t ->
    [> `Client of Error.t
    | `Database_unavailable of string
    | `Database of Trakeva.Error.t
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
-   Deferred_result.t
+    Deferred_result.t
 (** The latest contents of a given target.  *)
 
 val get_targets: t ->
@@ -123,9 +123,9 @@ val get_targets: t ->
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
-   Deferred_result.t
+    Deferred_result.t
 (** Same as {!get_target} but “in bulk.” *)
 
 val call_query: t -> target:Ketrew_pure.Target.t -> string ->
@@ -138,7 +138,7 @@ val kill: t ->
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
    | `Database_unavailable of Ketrew_pure.Target.id
-   | `Missing_data of Ketrew_pure.Target.id
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 (** Kill a set of targets. *)
@@ -149,7 +149,7 @@ val restart: t ->
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
    | `Database_unavailable of Ketrew_pure.Target.id
-   | `Missing_data of Ketrew_pure.Target.id
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 (** Restart a set of targets. *)
@@ -160,7 +160,7 @@ val add_targets: t ->
    [> `Client of Error.t
    | `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 (** Submit a list of targets to the server/engine. This is the low-level API

--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -136,8 +136,7 @@ module Run_automaton = struct
           end
         | `Error (`Database _ as e)
         | `Error (`Database_unavailable _ as e)
-        | `Error (`Missing_data _ as e) ->
-          (* Dependency not-found => should get out of the way *)
+        | `Error (`Fetching_node _ as e) ->
           log_error e
             Log.(s "Error while activating dependencies of " %
                  quote dependency_of % s " → "
@@ -283,9 +282,9 @@ module Run_automaton = struct
     end
 
   type step_allowed_errors = [
-    | `Database of  Trakeva.Error.t
-    | `Database_unavailable of Ketrew_pure.Target.id
-    | `Missing_data of Ketrew_pure.Target.id
+    | `Database of Trakeva.Error.t
+    | `Database_unavailable of string
+    | `Fetching_node of Persistent_data.Error.fetching_node
     | `Target of [ `Deserilization of string ]
     | `List of step_allowed_errors list
   ]

--- a/src/lib/engine.mli
+++ b/src/lib/engine.mli
@@ -31,7 +31,7 @@ val with_engine:
   (engine:t ->
    (unit, [> `Database of Trakeva.Error.t
           | `Failure of string
-          | `Missing_data of string
+          | `Fetching_node of Persistent_data.Error.fetching_node
           | `Database_unavailable of Ketrew_pure.Target.id
           | `Target of [> `Deserilization of string ]
           | `Dyn_plugin of
@@ -46,7 +46,7 @@ val load:
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of string
    | `Failure of string
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ]
    | `Dyn_plugin of
         [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
@@ -67,7 +67,7 @@ val add_targets :
   (unit,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of Ketrew_pure.Target.id
-   | `Missing_data of Ketrew_pure.Target.id
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ]
    ]) Deferred_result.t
 (** Add a list of targets to the engine. *)
@@ -76,7 +76,7 @@ val get_target: t -> Unique_id.t ->
   (Ketrew_pure.Target.t,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 (** Get a target from its id. *)
@@ -88,7 +88,7 @@ val all_visible_targets :
    | `Database_unavailable of string
     | `IO of
         [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
-    | `Missing_data of Ketrew_pure.Target.id
+    | `Fetching_node of Persistent_data.Error.fetching_node
     | `System of [> `File_info of string ] * [> `Exn of exn ]
     | `Target of [> `Deserilization of string ] ])
   Deferred_result.t
@@ -99,7 +99,7 @@ val get_list_of_target_ids: t ->
   (Ketrew_pure.Target.id list,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ]) Deferred_result.t
 (** Get only the Ids of the targets for a given “query”:
 
@@ -114,9 +114,9 @@ val next_changes: t -> (Persistent_data.Change.t list, 'a) Deferred_result.t
 module Run_automaton : sig
 
   type step_allowed_errors = [
-    | `Database of  Trakeva.Error.t
-    | `Database_unavailable of Ketrew_pure.Target.id
-    | `Missing_data of Ketrew_pure.Target.id
+    | `Database of Trakeva.Error.t
+    | `Database_unavailable of string
+    | `Fetching_node of Persistent_data.Error.fetching_node
     | `Target of [ `Deserilization of string ]
     | `List of step_allowed_errors list
   ]
@@ -148,7 +148,7 @@ val get_status : t -> Ketrew_pure.Target.id ->
    | `Database_unavailable of string
    | `IO of
         [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
-   | `Missing_data of string
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `System of [> `File_info of string ] * [> `Exn of exn ]
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
@@ -166,7 +166,7 @@ val restart_target: t -> Ketrew_pure.Target.id ->
   (Ketrew_pure.Target.id,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of Ketrew_pure.Target.id
-   | `Missing_data of Ketrew_pure.Target.id
+   | `Fetching_node of Persistent_data.Error.fetching_node
    | `Target of [> `Deserilization of string ] ]) Deferred_result.t
 (** Make new activated targets out of a given target and its “transitive
     reverse dependencies” *)

--- a/src/lib/engine.mli
+++ b/src/lib/engine.mli
@@ -138,8 +138,17 @@ module Run_automaton : sig
 
   val fix_point: t ->
     ([ `Steps of int], step_allowed_errors) Deferred_result.t
-    (** Run {!step} many times until nothing happens or nothing “new” happens. *)
+  (** Run {!step} many times until nothing happens or nothing “new” happens. *)
 
+
+  val try_to_fix_step_error: t ->
+    info:string ->
+    step_allowed_errors ->
+    (unit,
+     [> `Database of [> `Act of Trakeva.Action.t | `Load of string ] * string
+     | `Database_unavailable of string
+     | `Not_fixable of step_allowed_errors ])
+      Deferred_result.t
 end
 
 val get_status : t -> Ketrew_pure.Target.id ->

--- a/src/lib/error.ml
+++ b/src/lib/error.ml
@@ -87,7 +87,12 @@ let rec to_string = function
 | `Target (`Deserilization s) -> fmt "target-deserialization: %s" s
 | `Database_unavailable s -> fmt "DB %s" s
 | `Not_implemented s -> fmt "Not-impl %S" s
-| `Missing_data p -> fmt "missing data at id: %s" p
+| `Fetching_node (how, `Id id) ->
+  fmt "missing data at id: %s (%s)" id
+    (match how with
+    | `Get_stored_target -> "get_stored_target function"
+    | `Target_to_add  -> "getting target-to-add"
+    | `Pointer_loop_max_depth d -> fmt "pointer-max-depth reached: %d" d)
 | `Failed_to_kill msg -> fmt "Failed to kill target: %S" msg
 | `Long_running_failed_to_start (id, msg) ->
   fmt "Long running %s failed to start: %s" id msg

--- a/src/lib/explorer.mli
+++ b/src/lib/explorer.mli
@@ -34,7 +34,7 @@ val explore : t ->
          | `Failure of string
          | `IO of [> `Read_file_exn of string * exn
                   | `Write_file_exn of string * exn ]
-         | `Missing_data of string
+         | `Fetching_node of Persistent_data.Error.fetching_node
          | `System of [> `File_info of string ] * [> `Exn of exn ]
          | `Target of [> `Deserilization of string ] ]) Deferred_result.t
 (** [explore ~client exploration_states] runs a read-eval loop to explore and

--- a/src/lib/interaction.mli
+++ b/src/lib/interaction.mli
@@ -68,15 +68,15 @@ val build_sublist_of_targets :
   all_log:SmartPrint.t ->
   go_verb:SmartPrint.t ->
   filter:(Ketrew_pure.Target.t -> bool) ->
-    ([> `Cancel | `Go of string list ],
-     [> `Client of Client.Error.t
-      | `Database of Trakeva.Error.t
-      | `Database_unavailable of string
-      | `Failure of string
-      | `IO of [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
-      | `Missing_data of string
-      | `System of [> `File_info of string ] * [> `Exn of exn ]
-      | `Target of [> `Deserilization of string ] ]) t
+  ([> `Cancel | `Go of string list ],
+   [> `Client of Client.Error.t
+   | `Database of Trakeva.Error.t
+   | `Database_unavailable of string
+   | `Failure of string
+   | `IO of [> `Read_file_exn of string * exn | `Write_file_exn of string * exn ]
+   | `Fetching_node of Persistent_data.Error.fetching_node
+   | `System of [> `File_info of string ] * [> `Exn of exn ]
+   | `Target of [> `Deserilization of string ] ]) t
 (** Figure out the targets to be displayed. *)
 
 val make_target_menu : targets:Ketrew_pure.Target.t list ->

--- a/src/lib/logging.ml
+++ b/src/lib/logging.ml
@@ -159,6 +159,9 @@ module User_level_events = struct
       | `Server_shut_down
       | `Root_workflow_equivalent_to of string * string * (string * string) list
       | `Engine_fatal_error of string * [ `Retry_in of float ]
+      | `Tried_to_fix_engine_error of
+          [ `Info of string ] * [ `Error of string ]
+          * [ `Ok | `Not_fixable | `Error_again of string ]
     ]
     } [@@deriving yojson]
 
@@ -195,6 +198,12 @@ module User_level_events = struct
           in
           fmt "%d minutes and %d seconds" min sec
         end
+      | `Tried_to_fix_engine_error (`Info info, `Error err, result) ->
+        fmt "Tried to fix the engine: error %s %s → %s" err info
+          (match result with
+          | `Ok -> "Success!"
+          | `Not_fixable -> "Error is not considered fixable"
+          | `Error_again err -> fmt "New error: %s" err)
 
   type t = {
     ring: item Ring.t;
@@ -232,6 +241,9 @@ module User_level_events = struct
 
   let engine_fatal_error err sleep =
     add_item (`Engine_fatal_error (err, `Retry_in sleep))
+
+  let tried_to_fix_engine_error ~info err result =
+    add_item (`Tried_to_fix_engine_error (`Info info, `Error err, result))
 
   let get_notifications_or_block ~query =
     begin match query with

--- a/src/lib/logging.ml
+++ b/src/lib/logging.ml
@@ -158,6 +158,7 @@ module User_level_events = struct
       | `Workflow_node_restarted of string * string * string
       | `Server_shut_down
       | `Root_workflow_equivalent_to of string * string * (string * string) list
+      | `Engine_fatal_error of string * [ `Retry_in of float ]
     ]
     } [@@deriving yojson]
 
@@ -182,6 +183,18 @@ module User_level_events = struct
         name id
         (List.map name_ids ~f:(fun (name, id) -> fmt "%s (%s)" name id)
          |> String.concat ~sep:", ")
+    | `Engine_fatal_error (err, `Retry_in secs) ->
+      fmt "Engine ran into a fatal error: %s (retrying in %s)"
+        err
+        begin match secs with
+        | s when s < 60. -> fmt "%.0f seconds" s
+        | more ->
+          let min, sec = 
+            let s = int_of_float more in
+            s / 60, s mod 60
+          in
+          fmt "%d minutes and %d seconds" min sec
+        end
 
   type t = {
     ring: item Ring.t;
@@ -216,6 +229,9 @@ module User_level_events = struct
 
   let root_workflow_equivalent_to ~name ~id equivalences =
     add_item (`Root_workflow_equivalent_to (name, id, equivalences))
+
+  let engine_fatal_error err sleep =
+    add_item (`Engine_fatal_error (err, `Retry_in sleep))
 
   let get_notifications_or_block ~query =
     begin match query with

--- a/src/lib/named_hosts_text_ui.mli
+++ b/src/lib/named_hosts_text_ui.mli
@@ -33,7 +33,7 @@ val sub_commands:
     | `Dyn_plugin of [> `Dynlink_error of Dynlink.error | `Findlib of exn ]
     | `Failure of string
     | `IO of [> `Write_file_exn of string * exn ]
-    | `Missing_data of string
+    | `Fetching_node of Persistent_data.Error.fetching_node
     | `Target of [> `Deserilization of string ]
     | `Wrong_configuration of [> `Found of string ] * [> `Exn of exn ] ])
      Deferred_result.t Cmdliner.Term.t * Cmdliner.Term.info)

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -24,13 +24,21 @@ open Unix_io
 
 type t
 
+module Error : sig
+  type fetching_node = [
+    | `Get_stored_target
+    | `Pointer_loop_max_depth of int
+    | `Target_to_add 
+  ] * [ `Id of string ]
+end
+
 val create :
   database_parameters:string ->
   archival_age_threshold:[ `Days of float ] ->
   (t,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 
@@ -43,7 +51,7 @@ val get_target:
   (Ketrew_pure.Target.t,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 
@@ -52,7 +60,7 @@ val all_visible_targets :
   (Ketrew_pure.Target.t list,
    [>  `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 
@@ -69,7 +77,7 @@ val activate_target :
         | `Load of string ] *
         string
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 
@@ -84,7 +92,7 @@ val fold_active_targets :
            | `Iter of string
            | `Load of string ] *
            string
-      | `Missing_data of string
+      | `Fetching_node of Error.fetching_node
       | `Target of [> `Deserilization of string ] ]
       as 'combined_errors)
        Deferred_result.t) ->
@@ -104,7 +112,7 @@ val find_all_orphans:
   (Ketrew_pure.Target.t list,
    [> `Database of Trakeva.Error.t
    | `Database_unavailable of string
-   | `Missing_data of string
+   | `Fetching_node of Error.fetching_node
    | `Target of [> `Deserilization of string ] ])
     Deferred_result.t
 (** [find_all_orphans] goes through the cache and returns all the targets that
@@ -128,7 +136,7 @@ module Killing_targets: sig
           | `Load of string ] *
           string
      | `Database_unavailable of string
-     | `Missing_data of string
+     | `Fetching_node of Error.fetching_node
      | `Target of [> `Deserilization of string ] ])
       Deferred_result.t
   val add_target_ids_to_kill_list :
@@ -160,7 +168,7 @@ module Adding_targets: sig
           | `Load of string ] *
           string
      | `Database_unavailable of string
-     | `Missing_data of string
+     | `Fetching_node of Error.fetching_node
      | `Target of [> `Deserilization of string ] ])
       Deferred_result.t
 end
@@ -175,7 +183,7 @@ module Synchronize: sig
      | `IO of
           [> `Read_file_exn of string * exn
           | `Write_file_exn of string * exn ]
-     | `Missing_data of string
+     | `Fetching_node of Error.fetching_node
      | `Not_a_directory of string
      | `System of
           [> `File_info of string

--- a/src/lib/persistent_data.mli
+++ b/src/lib/persistent_data.mli
@@ -171,6 +171,14 @@ module Adding_targets: sig
      | `Fetching_node of Error.fetching_node
      | `Target of [> `Deserilization of string ] ])
       Deferred_result.t
+
+  (** Bypass the normal flow of target addition and put a target in the DB. *)
+  val force_add_passive_target: t ->
+    Ketrew_pure.Target.Stored_target.target ->
+    (unit,
+     [> `Database of [> `Act of Trakeva.Action.t | `Load of string ] * string
+     | `Database_unavailable of string ]) Deferred_result.t
+
 end
 
 module Synchronize: sig

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -729,8 +729,48 @@ let start_engine_loop ~server_state =
   let max_sleep = 120. in
   let error_time_factor = 4. in
   let error_max_sleep = 600. in
+  let errors_before_fixing = 5 in
+  let errors = Hashtbl.create 4 in
+  let add_error e =
+    let now = Time.now () in
+    match Hashtbl.find errors e with
+    | (nb, dates) -> Hashtbl.replace errors e (nb + 1, now :: dates)
+    | exception _ -> Hashtbl.add errors e (1, [now])
+  in
   let rec loop previous_sleep =
     begin
+      let to_fix =
+        Hashtbl.fold (fun err (nb, dates) prev ->
+            Printf.eprintf "E: %s -> %d\n%!"
+              (Error.to_string err) nb;
+            if nb >= errors_before_fixing
+            then (err, nb, dates) :: prev else prev) errors []
+      in
+      Deferred_list.for_concurrent to_fix  ~f:(fun (err, nb, dates) ->
+          let info =
+            fmt "happened %d times between %s and %s"
+              nb
+              (List.fold dates ~f:min ~init:infinity |> Time.to_string_hum)
+              (List.fold dates ~f:max ~init:0. |> Time.to_string_hum)
+          in
+          Engine.Run_automaton.try_to_fix_step_error server_state.state
+            ~info err
+          >>< function
+          | `Ok () ->
+            Hashtbl.remove errors err;
+            Logging.User_level_events.tried_to_fix_engine_error
+              ~info (Error.to_string err) `Ok;
+            return ()
+          | `Error (`Not_fixable ne) ->
+            Logging.User_level_events.tried_to_fix_engine_error
+              ~info (Error.to_string err) `Not_fixable;
+            return ()
+          | `Error ((`Database _ | `Database_unavailable _) as ne) ->
+            Logging.User_level_events.tried_to_fix_engine_error
+              ~info (Error.to_string err) (`Error_again (Error.to_string ne));
+            return ()
+        )
+      >>= fun ((_ : unit list), (_ : unit list)) ->
       Engine.Run_automaton.fix_point server_state.state
       >>< function
       | `Ok (`Steps step_count) ->
@@ -754,6 +794,7 @@ let start_engine_loop ~server_state =
               "Error", Error.to_string e |> text;
               "Sleep", time_span time_step;
             ]) in
+        add_error e;
         let sleep = min (previous_sleep *. error_time_factor) error_max_sleep in
         Logging.User_level_events.engine_fatal_error (Error.to_string e) sleep;
         return (markup, sleep)

--- a/src/lib/server.mli
+++ b/src/lib/server.mli
@@ -40,7 +40,7 @@ val start :
      | `Failure of string
      | `IO of
           [> `Read_file_exn of string * exn ]
-     | `Missing_data of string
+     | `Fetching_node of Persistent_data.Error.fetching_node
      | `Server_status_error of string
      | `Start_server_error of string
      | `System of

--- a/src/pure/target.ml
+++ b/src/pure/target.ml
@@ -513,7 +513,7 @@ that the potential condition has been ensured.
         "already-done" :: continue history
       | `Dependencies_failed (history, deps) ->
         let nb_deps = (List.length deps) in
-        fmt "%d depependenc%s failed" nb_deps (plural_of_int ~y:true nb_deps)
+        fmt "%d dependenc%s failed" nb_deps (plural_of_int ~y:true nb_deps)
         :: continue history
       | `Failed_running (history, reason, book) ->
         fmt "Reason: %S" (match reason with | `Long_running_failure s -> s)


### PR DESCRIPTION

This improves over the error handling that is on the engine.

The idea is that database errors are now really blocking the engine.

And on top of that Ketrew can now try to fix errors (after a given number of retries).

For now error fixing is just filling the database with "always failing" workflow-nodes.

Here we see that I inserted a node with missing dependencies, after a few retries (set to 2 here and 5 in the real), the fixing happens:

<img width="1244" alt="screenshot 2016-04-19 20 58 55" src="https://cloud.githubusercontent.com/assets/617111/14660229/95827e8c-0671-11e6-905d-16a20caea39d.png">

the DB gets fixed by adding a node:

<img width="1195" alt="screenshot 2016-04-19 21 00 54" src="https://cloud.githubusercontent.com/assets/617111/14660265/e766c3b6-0671-11e6-9f7e-aea202a94abc.png">




This happens to fix #428.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/430)
<!-- Reviewable:end -->
