### PR TITLE
export KETREW_PLAYGROUND for shell-based jobs

### DIFF
--- a/src/pure/monitored_script.ml
+++ b/src/pure/monitored_script.ml
@@ -61,8 +61,10 @@ let to_string ?(write_pid=true) t  =
       fmt "exit $%s" ret_v;
       "fi";
     ] in
+  let playground_path = (Path.to_string t.playground) in
   let script =
-    [ fmt "mkdir -p %s" (Path.to_string t.playground); ]
+    [ fmt "mkdir -p %s" playground_path; ]
+    @ [ fmt "export KETREW_PLAYGROUND='%s'" playground_path; ]
     @ (if write_pid then
          [fmt "echo \"$$\" > %s" (pid_file t |> Path.to_string)]
        else


### PR DESCRIPTION
When running a custom shell script as a job, this will come handy as a way to know where to save files. Another option is to always encourage shell scripts to `TMPFILE=$(mktemp)` and use that for temporary storage, but this will keep things better organized:

![demo](https://s3.amazonaws.com/f.cl.ly/items/0W433t3x2V2r2M1r121B/Screen%20Recording%202016-07-19%20at%2012.36%20PM.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/448)
<!-- Reviewable:end -->
