### PR TITLE
Implement temporary “freezing” of node states

### DIFF
--- a/src/lib/configuration.ml
+++ b/src/lib/configuration.ml
@@ -27,6 +27,7 @@ type plugin = [ `Compiled of string | `OCamlfind of string ]
               [@@deriving yojson]
 
 let default_archival_age_threashold = `Days 10.
+let default_freeze_state_duration = 30.
 
 type engine = {
   database_parameters: string;
@@ -34,8 +35,9 @@ type engine = {
   host_timeout_upper_bound: (float option [@default None]);
   maximum_successive_attempts: (int [@default 10]);
   concurrent_automaton_steps: (int [@default 4]);
-  archival_age_threshold: 
+  archival_age_threshold:
     ([ `Days of float ] [@default default_archival_age_threashold]);
+  freeze_state_duration: (float [@default default_freeze_state_duration]);
 } [@@deriving yojson]
 type explorer_defaults = {
   request_targets_ids: [ `All | `Younger_than of [ `Days of float ]];
@@ -134,7 +136,8 @@ let log t =
     ] in
   let engine { database_parameters; turn_unix_ssh_failure_into_target_failure;
                host_timeout_upper_bound; maximum_successive_attempts;
-               concurrent_automaton_steps; archival_age_threshold} =
+               concurrent_automaton_steps; archival_age_threshold;
+               freeze_state_duration} =
     sublist [
       item "Database" (quote database_parameters);
       item "Unix-failure"
@@ -147,6 +150,7 @@ let log t =
       item "Concurrent-automaton-steps" (i concurrent_automaton_steps);
       item "Archival-age-threshold"
         (match archival_age_threshold with `Days d -> sf "%f days" d);
+      item "Freeze-state-duration" (f freeze_state_duration);
     ] in
   let authorized_tokens = function
   | `Path path -> s "Path: " % quote path
@@ -230,6 +234,7 @@ let engine
     ?(maximum_successive_attempts=10)
     ?(concurrent_automaton_steps = 4)
     ?(archival_age_threshold = default_archival_age_threashold)
+    ?(freeze_state_duration = default_freeze_state_duration)
     () = {
   database_parameters;
   turn_unix_ssh_failure_into_target_failure;
@@ -237,6 +242,7 @@ let engine
   maximum_successive_attempts;
   concurrent_automaton_steps;
   archival_age_threshold;
+  freeze_state_duration;
 }
 let default_engine = engine ()
 
@@ -286,6 +292,7 @@ let daemon       s = s.daemon
 let log_path     s = s.log_path
 let database_parameters e = e.database_parameters
 let archival_age_threshold e = e.archival_age_threshold
+let freeze_state_duration e = e.freeze_state_duration
 let is_unix_ssh_failure_fatal e = e.turn_unix_ssh_failure_into_target_failure
 let maximum_successive_attempts e = e.maximum_successive_attempts
 let concurrent_automaton_steps e = e.concurrent_automaton_steps

--- a/src/lib/configuration.mli
+++ b/src/lib/configuration.mli
@@ -93,6 +93,7 @@ val engine:
   ?maximum_successive_attempts: int ->
   ?concurrent_automaton_steps: int ->
   ?archival_age_threshold : [ `Days of float ] ->
+  ?freeze_state_duration : float ->
   unit -> engine
 (** Build an [engine] configuration:
 
@@ -114,6 +115,9 @@ val engine:
       is [4]).
     - [archival_age_threshold]: amount of for which a finished workflow-node is
       visible in the user-interface (default: 10 days).
+    - [freeze_state_duration]: the maximal amount of time the engine
+      can “freeze” the state of a node for optimizations purposes
+      (default: [30.] seconds).
 *)
 
 type authorized_tokens 
@@ -274,7 +278,11 @@ val host_timeout_upper_bound : engine -> float option
 (** Get the upper bound for the timeout of SSH calls, if any. *)
 
 val archival_age_threshold: engine -> [ `Days of float ]
-(** Get the maximal ago of easily visible workflow-nodes *)
+(** Get the maximal ago of easily visible workflow-nodes. *)
+
+val freeze_state_duration: engine -> float
+(** Get the maximal time workflow-nodes can get frozen by the engine. *)
+
 
 val plugins: t ->  plugin list
 (** Get the configured list of plugins. *)

--- a/src/lib/engine.ml
+++ b/src/lib/engine.ml
@@ -332,14 +332,26 @@ module Run_automaton = struct
         "concurrency_number", textf "%d" concurrency_number;
       ] in
     let transitions_log = ref [] in
+    let frozen_nodes = ref [] in
     let step_target target :
       (* This type annotation is for safety, we want to know if a
          new kind of error appears here: *)
       (Ketrew_pure.Target.Automaton.progress list,
        [> `Database of [> `Act of Trakeva.Action.t | `Load of string ] * string
        | `Database_unavailable of string ]) Deferred_result.t =
+      let state_should_not_be_updated s =
+        match Target.State.Is.(still_running s || tried_to_eval_condition s) with
+        | false -> false
+        | true ->
+          let `Time time, _, _ = Target.State.summary s in
+          Time.now () -. time
+          < (Configuration.freeze_state_duration t.configuration)
+      in
       begin match Target.state target with
       | s when Target.State.Is.finished s ->
+        return []
+      | s when state_should_not_be_updated s ->
+        frozen_nodes := target :: !frozen_nodes;
         return []
       | other ->
         _process_automaton_transition t target
@@ -407,6 +419,14 @@ module Run_automaton = struct
               itemize !transitions_log
             | a_lot -> textf "%d" a_lot
           );
+          "frozen-nodes",
+          begin match List.length !frozen_nodes with
+          | 0 -> text "None"
+          | a_few when a_few < 8 ->
+            itemize (List.map !frozen_nodes ~f:(fun t ->
+                textf "%s (%s)" (Target.name t) (Target.id t)))
+          | a_lot -> textf "%d" a_lot
+          end;
           "has_progressed", bool has_progressed;
           "adding_did_something", bool adding_did_something;
           "killing_did_something", bool killing_did_something;

--- a/src/pure/target.mli
+++ b/src/pure/target.mli
@@ -167,6 +167,7 @@ module State : sig
     val failed_to_start : t -> bool
     val killing : t -> bool
     val tried_to_kill : t -> bool
+    val tried_to_eval_condition: t -> bool
     val did_not_ensure_condition : t -> bool
     val killed : t -> bool
     val finished : t -> bool


### PR DESCRIPTION
The idea is that when a node is in `` `Still_running`` or
`` `Tried_to_eval_condition`` states the engine will check again their
state only after a given amount of time (default 30 seconds).

This makes the engine more “reactive” to new workflows: a slow SSH
connection on an existing long-running job won't slow down the bootstrap
of a new workflow coming in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/449)
<!-- Reviewable:end -->
