### PR TITLE
Fix bug `Client.submit` for the lagacy API

### DIFF
--- a/src/lib/client.ml
+++ b/src/lib/client.ml
@@ -349,7 +349,9 @@ let flatten_to_pure_targets ?add_tags t =
         with
         | true -> ()
         | false ->
-          x#add_recursive_tags more_tags;
+          if more_tags <> [] then (
+            x#add_recursive_tags more_tags
+          );
           todo := x :: !todo
       ) in
   let add_to_return ~more_tags t =


### PR DESCRIPTION
This impacts only the old `EDSL.target`, that assumes one cannot add
tags afterwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/465)
<!-- Reviewable:end -->
