### PR TITLE
Update `Dockerfile` to Ubuntu 16.04

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:ubuntu-15.10_ocaml-4.02.3
+FROM ocaml/opam:ubuntu-16.04_ocaml-4.02.3
 RUN sudo apt-get install --yes libsqlite3-dev libev-dev libgmp-dev
 RUN opam install -y sqlite3 tls conf-libev
 RUN opam pin --yes add ketrew https://github.com/hammerlab/ketrew.git


### PR DESCRIPTION
It seems that 15.10 has not been built in a while.
The opam repository is outdated:
https://hub.docker.com/r/hammerlab/ketrew-server/builds/bp5s57haeo7q25ryaqmg5gf/

![screenshot 2016-09-06 14 55 45](https://cloud.githubusercontent.com/assets/617111/18286719/0bd94686-7442-11e6-91f2-cff357fc9506.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hammerlab/ketrew/467)
<!-- Reviewable:end -->
