### PR TITLE
Add the `~safe_ids` option for workflow submission

### DIFF
--- a/src/lib/client.mli
+++ b/src/lib/client.mli
@@ -107,7 +107,7 @@ val kill: t ->
    | `Database of Persistent_data.Error.database ])
     Deferred_result.t
 (** Kill a set of targets. *)
-    
+
 val restart: t ->
   Ketrew_pure.Target.id list ->
   (unit,
@@ -127,6 +127,7 @@ val add_targets: t ->
     see {!submit_workflow} below. *)
 
 val submit_workflow:
+  ?safe_ids: bool ->
   ?override_configuration:Configuration.t ->
   ?add_tags:string list ->
   'any EDSL.product EDSL.workflow_node ->
@@ -136,6 +137,10 @@ val submit_workflow:
 
     One can add tags to all the targets in the workflow before
     submitting with the [add_tags] option.
+
+    For experienced users: by default {!submit_workflow} makes IDs
+    unique within the workflow, one can override this by setting
+    [~safe_ids:false].
 *)
 
 val submit:
@@ -146,4 +151,3 @@ val submit:
 (** This is like {!submit_workflow} but for the deprecated/legacy API
     (i.e. created with calls to {!EDSL.user_target}).
 *)
-

--- a/src/pure/internal_pervasives.ml
+++ b/src/pure/internal_pervasives.ml
@@ -200,8 +200,12 @@ module Unique_id = struct
 
   (** Create a fresh filename-compliant identifier. *)
   let create () =
-    fmt "ketrew_%s_%09d"
+    fmt "%s_%09d"
       Time.(now () |> to_filename) (Random.int 1_000_000_000)
+
+  let add_prefix prefix t =
+    prefix ^ "_" ^ t
+
 end
 
 

--- a/src/pure/target.ml
+++ b/src/pure/target.ml
@@ -850,6 +850,17 @@ let create
     log = []; depends_on; make; condition; history; equivalence;
     on_failure_activate; on_success_activate; }
 
+let rekey ~prefix t = {
+  t with
+  id = Unique_id.add_prefix prefix t.id;
+  depends_on =
+    List.map t.depends_on ~f:(Unique_id.add_prefix prefix);
+  on_failure_activate =
+    List.map t.on_failure_activate ~f:(Unique_id.add_prefix prefix);
+  on_success_activate =
+    List.map t.on_success_activate ~f:(Unique_id.add_prefix prefix);
+}
+
 let to_serializable t = t
 let of_serializable t = t
 

--- a/src/pure/target.mli
+++ b/src/pure/target.mli
@@ -254,6 +254,8 @@ val create :
 (** Create a target value (not stored in the DB yet). *)
 
 
+val rekey: prefix:string -> t -> t
+(** Change all the IDs with {!Unique_id.add_prefix}. *)
 
 val id : t -> Unique_id.t
 (** Get a target's id. *)


### PR DESCRIPTION
This fixes #538.  

For the record, I was trying to add an extra layer of checks:

```ocaml
let check_ids node_list =
  let compare ta tb = String.compare (Target.id ta) (Target.id tb) in
  match  node_list |> List.find_a_dup ~compare with
  | None -> node_list
  | Some trgt ->
    Log.(s "Check-IDs-error: " % n
         % s "There are duplicate IDs within the workflow, \
              consider making your workflow generation not rely \
              on constants." % n
         % s "Example: " %n
         % Target.log trgt
         @ error);
    failwith (fmt  "Duplicate ID found: %s" (Target.id trgt))
```

But it's actually impossible to trigger, since the `flatten_to_pure_targets` already removes “internal duplicates.”


