### PR TITLE
Cohttp 1.0 compatibility

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -27,6 +27,8 @@ depends: [
   "yojson" "uri"
   "ppx_deriving"
   "ppx_deriving_yojson" {>= "3.0"}
+  "cohttp"
+  "cohttp-lwt" {>= "0.99.0"}
   "cohttp-lwt-unix" {>= "0.99.0"}
   "lwt"
   "conduit"

--- a/src/lib/client.ml
+++ b/src/lib/client.ml
@@ -86,7 +86,7 @@ module Http_client = struct
           Cohttp_lwt_unix.Client.call ~body meth uri)
     >>= fun (response, body) ->
     wrap_deferred ~on_exn:(fun e -> client_error ~where ~what:(`Exn e))
-      (fun () -> Cohttp_lwt_body.to_string body)
+      (fun () -> Cohttp_lwt.Body.to_string body)
     >>= fun body_str ->
     begin match Cohttp.Response.status response with
     | `OK ->

--- a/src/lib/server.ml
+++ b/src/lib/server.ml
@@ -131,7 +131,7 @@ type answer = [
 
 type 'error service =
   server_state:Server_state.t ->
-  body:Cohttp_lwt_body.t ->
+  body:Cohttp_lwt.Body.t ->
   Cohttp.Request.t ->
   (answer, 'error) Deferred_result.t
 (** A service is something that replies an [answer] on a ["/<path>"] URL. *)
@@ -142,7 +142,7 @@ module Request = struct
   type t = {
     id: string;
     cohttp_id: string;
-    body: Cohttp_lwt_body.t;
+    body: Cohttp_lwt.Body.t;
     req: Cohttp.Request.t;
     mutable log: (string * Display_markup.t) list;
   }
@@ -188,7 +188,7 @@ module Request = struct
     begin match Cohttp.Request.meth req with
     | `POST ->
       wrap_deferred ~on_exn:(fun e -> `IO (`Exn e))
-        (fun () -> Cohttp_lwt_body.to_string body)
+        (fun () -> Cohttp_lwt.Body.to_string body)
       >>= fun str ->
       add_log request Display_markup.[
           "body", big_string str;

--- a/src/lib/yarn.ml
+++ b/src/lib/yarn.ml
@@ -290,7 +290,7 @@ let yarn_api_get_app_raw ~host_io rp =
     Lwt.(fun () ->
         Cohttp_lwt_unix.Client.get to_call
         >>= fun (resp, body) ->
-        Cohttp_lwt_body.to_string body)
+        Cohttp_lwt.Body.to_string body)
 
 let parse_yarn_api_app_json s =
   begin try


### PR DESCRIPTION
Cohttp_lwt_body is now Cohttp_lwt.Body.

I've also added explicit deps on cohttp and cohttp-lwt. Yes, those were pulled transitively but it's best to use all the deps that you're using explicitly.